### PR TITLE
Apply `selected` attribute on option during initialization

### DIFF
--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -220,6 +220,9 @@ export class TPMultiSelectElement extends HTMLElement {
 		options.forEach( ( option: HTMLOptionElement ): void => {
 			const newOption: HTMLOptionElement = document.createElement( 'option' );
 			newOption.setAttribute( 'value', option.getAttribute( 'value' ) ?? '' );
+			if ( 'yes' === option.getAttribute( 'selected' ) ) {
+				newOption.setAttribute( 'selected', 'selected' );
+			}
 			selectElement?.append( newOption );
 		} );
 	}


### PR DESCRIPTION
## Description
There is a bug in `tp-multi-select` that `selected` attribute is not applied on `option` element when any `tp-multi-select-option` is selected.

https://github.com/Travelopia/web-components/assets/60139930/78344770-d773-4a40-a324-ed41e17c58ff

