### PR TITLE
Add Index On 'slide-set' Event

### DIFF
--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -152,7 +152,12 @@ export class TPSliderElement extends HTMLElement {
 			return;
 		}
 
-		this.dispatchEvent( new CustomEvent( 'slide-set', { bubbles: true } ) );
+		this.dispatchEvent( new CustomEvent( 'slide-set', {
+			bubbles: true,
+			detail: {
+				slideIndex: index,
+			},
+		} ) );
 		this.setAttribute( 'current-slide', index.toString() );
 	}
 


### PR DESCRIPTION
- Sometimes we the next slide-index before the slide changes. The getCurrentSlide() does not give that information.  
- This PR Adds index on 'slide-set' event in event details.