### PR TITLE
Update Multi-select component

### DIFF
--- a/src/multi-select/style.scss
+++ b/src/multi-select/style.scss
@@ -38,6 +38,10 @@ tp-multi-select-option {
 	&[disabled="yes"] {
 		opacity: 0.5;
 		cursor: not-allowed;
+
+		&:active {
+			pointer-events: none;
+		}
 	}
 }
 

--- a/src/multi-select/tp-multi-select-field.ts
+++ b/src/multi-select/tp-multi-select-field.ts
@@ -18,7 +18,6 @@ export class TPMultiSelectFieldElement extends HTMLElement {
 	 * Toggle opening this component.
 	 */
 	toggleOpen(): void {
-
 		const multiSelect: TPMultiSelectElement | null = this.closest( 'tp-multi-select' );
 		if ( ! multiSelect ) {
 			return;

--- a/src/multi-select/tp-multi-select-field.ts
+++ b/src/multi-select/tp-multi-select-field.ts
@@ -16,13 +16,8 @@ export class TPMultiSelectFieldElement extends HTMLElement {
 
 	/**
 	 * Toggle opening this component.
-	 *
-	 * @param {Event} e Click event.
 	 */
-	toggleOpen( e: Event ): void {
-		if ( this !== e.target ) {
-			return;
-		}
+	toggleOpen(): void {
 
 		const multiSelect: TPMultiSelectElement | null = this.closest( 'tp-multi-select' );
 		if ( ! multiSelect ) {

--- a/src/multi-select/tp-multi-select-option.ts
+++ b/src/multi-select/tp-multi-select-option.ts
@@ -28,8 +28,11 @@ export class TPMultiSelectOptionElement extends HTMLElement {
 
 		if ( 'yes' !== this.getAttribute( 'selected' ) ) {
 			multiSelect?.select( value );
+			multiSelect?.dispatchEvent( new CustomEvent( 'select', { bubbles: true } ) );
 		} else {
 			multiSelect?.unSelect( value );
+			multiSelect?.dispatchEvent( new CustomEvent( 'unselect', { bubbles: true } ) );
 		}
+		multiSelect?.dispatchEvent( new CustomEvent( 'change', { bubbles: true } ) );
 	}
 }

--- a/src/multi-select/tp-multi-select-pill.ts
+++ b/src/multi-select/tp-multi-select-pill.ts
@@ -32,6 +32,8 @@ export class TPMultiSelectPillElement extends HTMLElement {
 		const multiSelect: TPMultiSelectElement | null = this.closest( 'tp-multi-select' );
 		if ( multiSelect && this.getAttribute( 'value' ) ) {
 			multiSelect.unSelect( this.getAttribute( 'value' ) ?? '' );
+			multiSelect.dispatchEvent( new CustomEvent( 'unselect', { bubbles: true } ) );
+			multiSelect.dispatchEvent( new CustomEvent( 'change', { bubbles: true } ) );
 		}
 	}
 }

--- a/src/multi-select/tp-multi-select-pills.ts
+++ b/src/multi-select/tp-multi-select-pills.ts
@@ -14,6 +14,7 @@ export class TPMultiSelectPillsElement extends HTMLElement {
 	 */
 	connectedCallback(): void {
 		this.closest( 'tp-multi-select' )?.addEventListener( 'change', this.update.bind( this ) );
+		this.update();
 	}
 
 	/**

--- a/src/multi-select/tp-multi-select-search.ts
+++ b/src/multi-select/tp-multi-select-search.ts
@@ -83,7 +83,7 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 			multiSelect.setAttribute( 'open', 'yes' );
 		}
 
-		multiSelect.setAttribute( 'matched-options-count', matchedOptionCount.toString() );
+		multiSelect.setAttribute( 'visible-options', matchedOptionCount.toString() );
 	}
 
 	/**

--- a/src/multi-select/tp-multi-select-search.ts
+++ b/src/multi-select/tp-multi-select-search.ts
@@ -20,7 +20,7 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 
 		input.addEventListener( 'keydown', this.handleKeyboardInputs.bind( this ) );
 		input.addEventListener( 'keyup', this.handleSearchChange.bind( this ) );
-		input.addEventListener( 'change', this.handleSearchChange.bind( this ) );
+		input.addEventListener( 'input', this.handleSearchChange.bind( this ) );
 		this.addEventListener( 'click', this.handleClick.bind( this ) );
 		this.closest( 'tp-multi-select' )?.addEventListener( 'open', this.focus.bind( this ) );
 	}
@@ -64,10 +64,12 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 			return;
 		}
 
+		let matchedOptionCount = 0;
 		// Hide and show options based on search.
 		options.forEach( ( option: TPMultiSelectOptionElement ): void => {
 			if ( option.getAttribute( 'value' )?.match( new RegExp( `.*${ search.value }.*` ) ) ) {
 				option.removeAttribute( 'hidden' );
+				matchedOptionCount++;
 			} else {
 				option.setAttribute( 'hidden', 'yes' );
 			}
@@ -80,6 +82,8 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 			search.style.width = `${ search.value.length + 2 }ch`;
 			multiSelect.setAttribute( 'open', 'yes' );
 		}
+
+		multiSelect.setAttribute( 'matched-options-count', matchedOptionCount.toString() );
 	}
 
 	/**

--- a/src/multi-select/tp-multi-select-select-all.ts
+++ b/src/multi-select/tp-multi-select-select-all.ts
@@ -46,8 +46,11 @@ export class TPMultiSelectSelectAllElement extends HTMLElement {
 
 		if ( 'yes' !== this.getAttribute( 'selected' ) ) {
 			multiSelect.selectAll();
+			multiSelect.dispatchEvent( new CustomEvent( 'select-all', { bubbles: true } ) );
 		} else {
 			multiSelect.unSelectAll();
+			multiSelect.dispatchEvent( new CustomEvent( 'unselect-all', { bubbles: true } ) );
 		}
+		multiSelect.dispatchEvent( new CustomEvent( 'change', { bubbles: true } ) );
 	}
 }

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -108,9 +108,8 @@ export class TPMultiSelectElement extends HTMLElement {
 
 		const selectedOptions: NodeListOf<HTMLOptionElement> | null = this.querySelectorAll( 'select option[selected]' );
 		selectedOptions?.forEach( ( option: HTMLOptionElement ) => {
-			const isSelected = 'selected' === option.getAttribute( 'selected' );
 			const optionValue = option.getAttribute( 'value' );
-			if ( isSelected && optionValue ) {
+			if ( optionValue ) {
 				value.push( optionValue );
 			}
 		} );

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -129,11 +129,13 @@ export class TPMultiSelectElement extends HTMLElement {
 			return;
 		}
 
+		const selectOptions: HTMLOptionElement[] = Array.from( selectField.options );
+
 		// Traverse options.
 		styledSelectedOptions.forEach( ( option: TPMultiSelectOptionElement ): void => {
 			const optionValue = option.getAttribute( 'value' ) ?? '';
 			if ( optionValue ) {
-				const matchingSelectOption: HTMLOptionElement | null = this.querySelector( `select option[value="${ optionValue }"]` );
+				const matchingSelectOption: HTMLOptionElement | undefined = selectOptions.find( ( selectOption ) => selectOption.value === optionValue );
 
 				if ( 'yes' === option.getAttribute( 'selected' ) ) {
 					if ( matchingSelectOption ) {

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -341,27 +341,34 @@ export class TPMultiSelectElement extends HTMLElement {
 	 */
 	highlightNextOption(): void {
 		// Get options.
-		const options: NodeListOf<TPMultiSelectOptionElement> | null = this.querySelectorAll( 'tp-multi-select-option:not([hidden="yes"])' );
-		if ( ! options ) {
+		const options: NodeListOf<TPMultiSelectOptionElement> | null = this.querySelectorAll('tp-multi-select-option:not([hidden="yes"])');
+    
+		if ( !options ) {
 			this.currentlyHighlightedOption = -1;
 			return;
 		}
-
-		// Highlight next option.
-		if ( this.currentlyHighlightedOption === options.length - 1 ) {
+	
+		// Find the next option to be highlighted.
+		let nextToBeHighlighted = this.currentlyHighlightedOption + 1;
+	
+		while (nextToBeHighlighted < options.length && options[nextToBeHighlighted].getAttribute('disabled') === 'yes') {
+			nextToBeHighlighted++;
+		}
+	
+		if (nextToBeHighlighted === options.length) {
 			return;
 		}
-
-		this.currentlyHighlightedOption++;
-
-		// Set option attributes based on highlight.
-		options.forEach( ( option: TPMultiSelectOptionElement, index: number ): void => {
-			if ( this.currentlyHighlightedOption === index ) {
-				option.setAttribute( 'highlighted', 'yes' );
-			} else {
-				option.removeAttribute( 'highlighted' );
-			}
-		} );
+	
+		// Remove highlight from the current option, if any.
+		if (this.currentlyHighlightedOption !== -1) {
+			options[this.currentlyHighlightedOption].removeAttribute('highlighted');
+		}
+	
+		// Highlight the next option.
+		options[nextToBeHighlighted].setAttribute('highlighted', 'yes');
+		options[nextToBeHighlighted].scrollIntoView(false);
+	
+		this.currentlyHighlightedOption = nextToBeHighlighted;
 	}
 
 	/**
@@ -375,21 +382,26 @@ export class TPMultiSelectElement extends HTMLElement {
 			return;
 		}
 
-		// Highlight next option.
-		if ( this.currentlyHighlightedOption === 0 ) {
+		// Find the previous option to be highlighted.
+		let previousToBeHighlighted = this.currentlyHighlightedOption - 1;
+
+		while( previousToBeHighlighted >= 0 && options[previousToBeHighlighted].getAttribute('disabled') === 'yes' ) {
+			previousToBeHighlighted--;
+		}
+
+		if ( previousToBeHighlighted < 0 ) {
 			return;
 		}
 
-		this.currentlyHighlightedOption--;
+		if ( this.currentlyHighlightedOption !== 0 ) {
+			options[this.currentlyHighlightedOption].removeAttribute('highlighted');
+		}
 
-		// Set option attributes based on highlight.
-		options.forEach( ( option: TPMultiSelectOptionElement, index: number ): void => {
-			if ( this.currentlyHighlightedOption === index ) {
-				option.setAttribute( 'highlighted', 'yes' );
-			} else {
-				option.removeAttribute( 'highlighted' );
-			}
-		} );
+		options[previousToBeHighlighted].setAttribute('highlighted', 'yes');
+		options[previousToBeHighlighted].scrollIntoView(false);
+
+		this.currentlyHighlightedOption = previousToBeHighlighted;
+
 	}
 
 	/**

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -106,9 +106,14 @@ export class TPMultiSelectElement extends HTMLElement {
 	get value(): string[] {
 		const value: string[] = [];
 
-		const selectedOptions: NodeListOf<HTMLOptionElement> | null = this.querySelectorAll( 'select option[selected]' );
-		selectedOptions?.forEach( ( option: HTMLOptionElement ) => value.push( option.value ) );
-
+		const selectedOptions: NodeListOf<HTMLOptionElement> | null = this.querySelectorAll( 'tp-multi-select-option' );
+		selectedOptions?.forEach( ( option: HTMLOptionElement ) => {
+			const isSelected = 'yes' === option.getAttribute( 'selected' );
+			const optionValue = option.getAttribute( 'value' );
+			if ( isSelected && optionValue ) {
+				value.push( optionValue );
+			}
+		} );
 		return value;
 	}
 
@@ -192,12 +197,6 @@ export class TPMultiSelectElement extends HTMLElement {
 	 * Initialize component.
 	 */
 	initialize(): void {
-		// Get options.
-		const options: NodeListOf<HTMLOptionElement> | null = this.querySelectorAll( 'tp-multi-select-option' );
-		if ( ! options ) {
-			return;
-		}
-
 		// Create select element (if it doesn't already exist).
 		let selectElement: HTMLSelectElement | null = this.querySelector( 'select' );
 		if ( ! selectElement ) {
@@ -213,6 +212,7 @@ export class TPMultiSelectElement extends HTMLElement {
 			selectElement.innerHTML = '';
 		}
 
+		// Update components for selected options.
 		this.update();
 	}
 

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -324,19 +324,20 @@ export class TPMultiSelectElement extends HTMLElement {
 	highlightNextOption(): void {
 		// Get options.
 		const options: NodeListOf<TPMultiSelectOptionElement> | null = this.querySelectorAll( 'tp-multi-select-option:not([hidden="yes"])' );
-
 		if ( ! options ) {
 			this.currentlyHighlightedOption = -1;
 			return;
 		}
 
-		// Find the next option to be highlighted.
+		// Find the next option to be highlighted. Assume next option is the favorable option.
 		let nextToBeHighlighted = this.currentlyHighlightedOption + 1;
 
+		// Keep iterating to skip over disabled options until we find a suitable option.
 		while ( nextToBeHighlighted < options.length && options[ nextToBeHighlighted ].getAttribute( 'disabled' ) === 'yes' ) {
 			nextToBeHighlighted++;
 		}
 
+		// If there are no more options to highlight, exit. Here, the last highlighted option keeps highlighted.
 		if ( nextToBeHighlighted === options.length ) {
 			return;
 		}
@@ -346,10 +347,13 @@ export class TPMultiSelectElement extends HTMLElement {
 			options[ this.currentlyHighlightedOption ].removeAttribute( 'highlighted' );
 		}
 
-		// Highlight the next option.
+		// Highlight the found option.
 		options[ nextToBeHighlighted ].setAttribute( 'highlighted', 'yes' );
+
+		// Scroll the highlighted option into view with smooth behavior.
 		options[ nextToBeHighlighted ].scrollIntoView( { behavior: 'smooth', block: 'nearest' } );
 
+		// Update the currentlyHighlightedOption for the next iteration.
 		this.currentlyHighlightedOption = nextToBeHighlighted;
 	}
 
@@ -364,24 +368,31 @@ export class TPMultiSelectElement extends HTMLElement {
 			return;
 		}
 
-		// Find the previous option to be highlighted.
+		// Find the previous option to be highlighted. Assume previous option is the favorable option.
 		let previousToBeHighlighted = this.currentlyHighlightedOption - 1;
 
+		// Keep iterating to skip over disabled options until we find a suitable option.
 		while ( previousToBeHighlighted >= 0 && options[ previousToBeHighlighted ].getAttribute( 'disabled' ) === 'yes' ) {
 			previousToBeHighlighted--;
 		}
 
+		// If there are no more options to highlight, exit.
 		if ( previousToBeHighlighted < 0 ) {
 			return;
 		}
 
+		// Remove highlight from the current option, if any.
 		if ( this.currentlyHighlightedOption !== 0 ) {
 			options[ this.currentlyHighlightedOption ].removeAttribute( 'highlighted' );
 		}
 
+		// Highlight the found option.
 		options[ previousToBeHighlighted ].setAttribute( 'highlighted', 'yes' );
+
+		// Scroll the highlighted option into view with smooth behavior.
 		options[ previousToBeHighlighted ].scrollIntoView( { behavior: 'smooth', block: 'nearest' } );
 
+		// Update the currentlyHighlightedOption for the next iteration.
 		this.currentlyHighlightedOption = previousToBeHighlighted;
 	}
 

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -300,12 +300,13 @@ export class TPMultiSelectElement extends HTMLElement {
 	 * @param {Event} e Keyboard event.
 	 */
 	handleKeyboardInputs( e: KeyboardEvent ): void {
-		e.preventDefault();
 		switch ( e.key ) {
 			case 'ArrowDown':
+				e.preventDefault();
 				this.highlightNextOption();
 				break;
 			case 'ArrowUp':
+				e.preventDefault();
 				this.highlightPreviousOption();
 				break;
 			case 'Enter':

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -341,33 +341,33 @@ export class TPMultiSelectElement extends HTMLElement {
 	 */
 	highlightNextOption(): void {
 		// Get options.
-		const options: NodeListOf<TPMultiSelectOptionElement> | null = this.querySelectorAll('tp-multi-select-option:not([hidden="yes"])');
-    
-		if ( !options ) {
+		const options: NodeListOf<TPMultiSelectOptionElement> | null = this.querySelectorAll( 'tp-multi-select-option:not([hidden="yes"])' );
+
+		if ( ! options ) {
 			this.currentlyHighlightedOption = -1;
 			return;
 		}
-	
+
 		// Find the next option to be highlighted.
 		let nextToBeHighlighted = this.currentlyHighlightedOption + 1;
-	
-		while (nextToBeHighlighted < options.length && options[nextToBeHighlighted].getAttribute('disabled') === 'yes') {
+
+		while ( nextToBeHighlighted < options.length && options[ nextToBeHighlighted ].getAttribute( 'disabled' ) === 'yes' ) {
 			nextToBeHighlighted++;
 		}
-	
-		if (nextToBeHighlighted === options.length) {
+
+		if ( nextToBeHighlighted === options.length ) {
 			return;
 		}
-	
+
 		// Remove highlight from the current option, if any.
-		if (this.currentlyHighlightedOption !== -1) {
-			options[this.currentlyHighlightedOption].removeAttribute('highlighted');
+		if ( this.currentlyHighlightedOption !== -1 ) {
+			options[ this.currentlyHighlightedOption ].removeAttribute( 'highlighted' );
 		}
-	
+
 		// Highlight the next option.
-		options[nextToBeHighlighted].setAttribute('highlighted', 'yes');
-		options[nextToBeHighlighted].scrollIntoView(false);
-	
+		options[ nextToBeHighlighted ].setAttribute( 'highlighted', 'yes' );
+		options[ nextToBeHighlighted ].scrollIntoView( false );
+
 		this.currentlyHighlightedOption = nextToBeHighlighted;
 	}
 
@@ -385,7 +385,7 @@ export class TPMultiSelectElement extends HTMLElement {
 		// Find the previous option to be highlighted.
 		let previousToBeHighlighted = this.currentlyHighlightedOption - 1;
 
-		while( previousToBeHighlighted >= 0 && options[previousToBeHighlighted].getAttribute('disabled') === 'yes' ) {
+		while ( previousToBeHighlighted >= 0 && options[ previousToBeHighlighted ].getAttribute( 'disabled' ) === 'yes' ) {
 			previousToBeHighlighted--;
 		}
 
@@ -394,14 +394,13 @@ export class TPMultiSelectElement extends HTMLElement {
 		}
 
 		if ( this.currentlyHighlightedOption !== 0 ) {
-			options[this.currentlyHighlightedOption].removeAttribute('highlighted');
+			options[ this.currentlyHighlightedOption ].removeAttribute( 'highlighted' );
 		}
 
-		options[previousToBeHighlighted].setAttribute('highlighted', 'yes');
-		options[previousToBeHighlighted].scrollIntoView(false);
+		options[ previousToBeHighlighted ].setAttribute( 'highlighted', 'yes' );
+		options[ previousToBeHighlighted ].scrollIntoView( false );
 
 		this.currentlyHighlightedOption = previousToBeHighlighted;
-
 	}
 
 	/**

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -225,6 +225,8 @@ export class TPMultiSelectElement extends HTMLElement {
 			}
 			selectElement?.append( newOption );
 		} );
+
+		this.update();
 	}
 
 	/**
@@ -366,7 +368,6 @@ export class TPMultiSelectElement extends HTMLElement {
 
 		// Highlight the next option.
 		options[ nextToBeHighlighted ].setAttribute( 'highlighted', 'yes' );
-		options[ nextToBeHighlighted ].scrollIntoView( false );
 
 		this.currentlyHighlightedOption = nextToBeHighlighted;
 	}
@@ -398,7 +399,6 @@ export class TPMultiSelectElement extends HTMLElement {
 		}
 
 		options[ previousToBeHighlighted ].setAttribute( 'highlighted', 'yes' );
-		options[ previousToBeHighlighted ].scrollIntoView( false );
 
 		this.currentlyHighlightedOption = previousToBeHighlighted;
 	}

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -253,10 +253,6 @@ export class TPMultiSelectElement extends HTMLElement {
 		if ( 'yes' === this.getAttribute( 'close-on-select' ) ) {
 			this.removeAttribute( 'open' );
 		}
-
-		// Trigger events.
-		this.dispatchEvent( new CustomEvent( 'select', { bubbles: true } ) );
-		this.dispatchEvent( new CustomEvent( 'change', { bubbles: true } ) );
 	}
 
 	/**
@@ -269,9 +265,6 @@ export class TPMultiSelectElement extends HTMLElement {
 				option.setAttribute( 'selected', 'yes' );
 			}
 		} );
-
-		this.dispatchEvent( new CustomEvent( 'select-all', { bubbles: true } ) );
-		this.dispatchEvent( new CustomEvent( 'change', { bubbles: true } ) );
 	}
 
 	/**
@@ -284,9 +277,6 @@ export class TPMultiSelectElement extends HTMLElement {
 		styledSelectedOptions?.forEach( ( option: TPMultiSelectOptionElement ): void => {
 			option.removeAttribute( 'selected' );
 		} );
-
-		this.dispatchEvent( new CustomEvent( 'unselect', { bubbles: true } ) );
-		this.dispatchEvent( new CustomEvent( 'change', { bubbles: true } ) );
 	}
 
 	/**
@@ -297,9 +287,6 @@ export class TPMultiSelectElement extends HTMLElement {
 		styledSelectedOptions?.forEach( ( option: TPMultiSelectOptionElement ): void => {
 			option.removeAttribute( 'selected' );
 		} );
-
-		this.dispatchEvent( new CustomEvent( 'unselect-all', { bubbles: true } ) );
-		this.dispatchEvent( new CustomEvent( 'change', { bubbles: true } ) );
 	}
 
 	/**

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -133,7 +133,7 @@ export class TPMultiSelectElement extends HTMLElement {
 		styledSelectedOptions.forEach( ( option: TPMultiSelectOptionElement ): void => {
 			const optionValue = option.getAttribute( 'value' ) ?? '';
 			if ( optionValue ) {
-				const matchingSelectOption: HTMLOptionElement | null = document.querySelector( `select option[value=${ optionValue }]` );
+				const matchingSelectOption: HTMLOptionElement | null = this.querySelector( `select option[value="${ optionValue }"]` );
 
 				if ( 'yes' === option.getAttribute( 'selected' ) ) {
 					if ( matchingSelectOption ) {

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -106,9 +106,9 @@ export class TPMultiSelectElement extends HTMLElement {
 	get value(): string[] {
 		const value: string[] = [];
 
-		const selectedOptions: NodeListOf<HTMLOptionElement> | null = this.querySelectorAll( 'tp-multi-select-option' );
+		const selectedOptions: NodeListOf<HTMLOptionElement> | null = this.querySelectorAll( 'select option[selected]' );
 		selectedOptions?.forEach( ( option: HTMLOptionElement ) => {
-			const isSelected = 'yes' === option.getAttribute( 'selected' );
+			const isSelected = 'selected' === option.getAttribute( 'selected' );
 			const optionValue = option.getAttribute( 'value' );
 			if ( isSelected && optionValue ) {
 				value.push( optionValue );
@@ -253,6 +253,7 @@ export class TPMultiSelectElement extends HTMLElement {
 		if ( 'yes' === this.getAttribute( 'close-on-select' ) ) {
 			this.removeAttribute( 'open' );
 		}
+		this.update();
 	}
 
 	/**
@@ -265,6 +266,7 @@ export class TPMultiSelectElement extends HTMLElement {
 				option.setAttribute( 'selected', 'yes' );
 			}
 		} );
+		this.update();
 	}
 
 	/**
@@ -277,6 +279,7 @@ export class TPMultiSelectElement extends HTMLElement {
 		styledSelectedOptions?.forEach( ( option: TPMultiSelectOptionElement ): void => {
 			option.removeAttribute( 'selected' );
 		} );
+		this.update();
 	}
 
 	/**
@@ -287,6 +290,7 @@ export class TPMultiSelectElement extends HTMLElement {
 		styledSelectedOptions?.forEach( ( option: TPMultiSelectOptionElement ): void => {
 			option.removeAttribute( 'selected' );
 		} );
+		this.update();
 	}
 
 	/**

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -118,33 +118,30 @@ export class TPMultiSelectElement extends HTMLElement {
 	protected updateFormFieldValue(): void {
 		// Get options.
 		const styledSelectedOptions: NodeListOf<TPMultiSelectOptionElement> | null = this.querySelectorAll( `tp-multi-select-option` );
-		const selectFieldOptions: NodeListOf<HTMLOptionElement> | null = this.querySelectorAll( 'select option' );
+		const selectField: HTMLSelectElement | null = this.querySelector( 'select' );
 
-		if ( ! styledSelectedOptions || ! selectFieldOptions ) {
+		if ( ! styledSelectedOptions || ! selectField ) {
 			return;
 		}
 
 		// Traverse options.
 		styledSelectedOptions.forEach( ( option: TPMultiSelectOptionElement ): void => {
-			// Get matching select field options.
-			const matchingSelectOptions: HTMLOptionElement[] = [ ...selectFieldOptions ].filter( ( selectOption: HTMLOptionElement ): boolean =>
-				selectOption.getAttribute( 'value' ) === option.getAttribute( 'value' ) );
+			const optionValue = option.getAttribute( 'value' ) ?? '';
+			if ( optionValue ) {
+				const matchingSelectOption: HTMLOptionElement | null = document.querySelector( `select option[value=${ optionValue }]` );
 
-			if ( 0 === matchingSelectOptions.length ) {
-				return;
-			}
-
-			// Check whether to mark them as selected or not.
-			if ( 'yes' === option.getAttribute( 'selected' ) ) {
-				matchingSelectOptions.forEach( ( matchingSelectOption: HTMLOptionElement ): void => {
-					matchingSelectOption.selected = true;
-					matchingSelectOption.setAttribute( 'selected', 'selected' );
-				} );
-			} else {
-				matchingSelectOptions.forEach( ( matchingSelectOption: HTMLOptionElement ): void => {
-					matchingSelectOption.selected = false;
-					matchingSelectOption.removeAttribute( 'selected' );
-				} );
+				if ( 'yes' === option.getAttribute( 'selected' ) ) {
+					if ( matchingSelectOption ) {
+						matchingSelectOption.setAttribute( 'selected', 'selected' );
+					} else {
+						const newOption: HTMLOptionElement = document.createElement( 'option' );
+						newOption.setAttribute( 'value', option.getAttribute( 'value' ) ?? '' );
+						newOption.setAttribute( 'selected', 'selected' );
+						selectField?.append( newOption );
+					}
+				} else if ( matchingSelectOption ) {
+					matchingSelectOption.remove();
+				}
 			}
 		} );
 
@@ -215,16 +212,6 @@ export class TPMultiSelectElement extends HTMLElement {
 		} else {
 			selectElement.innerHTML = '';
 		}
-
-		// Append new options.
-		options.forEach( ( option: HTMLOptionElement ): void => {
-			const newOption: HTMLOptionElement = document.createElement( 'option' );
-			newOption.setAttribute( 'value', option.getAttribute( 'value' ) ?? '' );
-			if ( 'yes' === option.getAttribute( 'selected' ) ) {
-				newOption.setAttribute( 'selected', 'selected' );
-			}
-			selectElement?.append( newOption );
-		} );
 
 		this.update();
 	}

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -144,14 +144,14 @@ export class TPMultiSelectElement extends HTMLElement {
 						newOption.setAttribute( 'selected', 'selected' );
 						selectField?.append( newOption );
 					}
-				} else if ( matchingSelectOption ) {
-					matchingSelectOption.remove();
+				} else {
+					matchingSelectOption?.remove();
 				}
 			}
 		} );
 
 		// Dispatch events.
-		this.querySelector( 'select' )?.dispatchEvent( new Event( 'change' ) );
+		selectField.dispatchEvent( new Event( 'change' ) );
 	}
 
 	/**

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -300,6 +300,7 @@ export class TPMultiSelectElement extends HTMLElement {
 	 * @param {Event} e Keyboard event.
 	 */
 	handleKeyboardInputs( e: KeyboardEvent ): void {
+		e.preventDefault();
 		switch ( e.key ) {
 			case 'ArrowDown':
 				this.highlightNextOption();
@@ -347,6 +348,7 @@ export class TPMultiSelectElement extends HTMLElement {
 
 		// Highlight the next option.
 		options[ nextToBeHighlighted ].setAttribute( 'highlighted', 'yes' );
+		options[ nextToBeHighlighted ].scrollIntoView( { behavior: 'smooth', block: 'nearest' } );
 
 		this.currentlyHighlightedOption = nextToBeHighlighted;
 	}
@@ -378,6 +380,7 @@ export class TPMultiSelectElement extends HTMLElement {
 		}
 
 		options[ previousToBeHighlighted ].setAttribute( 'highlighted', 'yes' );
+		options[ previousToBeHighlighted ].scrollIntoView( { behavior: 'smooth', block: 'nearest' } );
 
 		this.currentlyHighlightedOption = previousToBeHighlighted;
 	}


### PR DESCRIPTION
## Description 
This PR updates the multi-select component which fixes following bugs - 

- [x] skip disabled options during navigation
- [x] scroll option into view during keyboard navigaiton
- [x] initialize multi-select with initial options on first page load
- [x] avoid submitting the first option when single select is used in a form
- [x] Some bug fixes

### Technical choices

1. `update` function is triggered on initialization for main component and the pills component in-order to update the selected options.
2. To avoid submitted the first option, the code has been refactored specifically the `updateFormField` method. We are now creating `select` option dynamically on user's selection. By default, a select will be rendered without any option. If a user selects a `tp-multi-select-option`, we update the DOM by appending a option to it. If de-selected, we remove the same. Also, during the first load, if some tp-options are already selected, we update the `select` tag as well.
3. With respect to [this bug](https://github.com/Travelopia/web-components/issues/15#issuecomment-1872987098), code is refactored to dispatch events on only user trigger.
4. Disable any pointer event for disabled options
5. Listener on `tp-mult-select-search` is changed from `change` to `input`
6. An attribute `visible-options` is introduced to expose the number of options resulted in a search. This would be helpful in knowing the count to show/hide 'No result' by any library implementor.

### Issues
Partially closes - #15 