### PR TITLE
Update Multi-Select Select All Feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travelopia/web-components",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Accessible web components for the modern web",
   "files": [
     "dist"

--- a/src/multi-select/README.md
+++ b/src/multi-select/README.md
@@ -86,11 +86,12 @@ const value = multiSelect.value;
 
 ## Attributes
 
-| Attribute       | Required | Values                   | Notes                                                                               |
-|-----------------|----------|--------------------------|-------------------------------------------------------------------------------------|
-| name            | Yes      | <name of the form field> | Whether the height of the slider changes depending on the content inside the slides |
-| multiple        | No       | `yes`, `no`               | Whether the field needs to be a single or mult-select form field. Yes by default    |
-| close-on-select | No       | `yes`                    | Whether to close the options when a value is selected                               |
+| Attribute       | Required | Values                   | Notes                                                                                                                        |
+|-----------------|----------|--------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| name            | Yes      | <name of the form field> | Whether the height of the slider changes depending on the content inside the slides                                          |
+| multiple        | No       | `yes`, `no`              | Whether the field needs to be a single or mult-select form field. Yes by default                                             |
+| close-on-select | No       | `yes`                    | Whether to close the options when a value is selected                                                                        |
+| select-all-text | No       | `All Selected`           | When a text value is passed, it will show that value when Select All is clicked and won't show all selected pills in the box |
 
 ## Events
 

--- a/src/multi-select/index.html
+++ b/src/multi-select/index.html
@@ -122,6 +122,8 @@
 				<tp-multi-select-option value="jane" label="Jane">Jane</tp-multi-select-option>
 				<tp-multi-select-option value="jack" label="Jack">Jack</tp-multi-select-option>
 				<tp-multi-select-option value="jill" label="Jill" disabled="yes">Jill</tp-multi-select-option>
+				<tp-multi-select-option value="abu simbel" label="Abul Simbel">Abu Simbel</tp-multi-select-option>
+				<tp-multi-select-option value="Africa" label="Africa">Africa</tp-multi-select-option>
 			</tp-multi-select-options>
 		</tp-multi-select>
 	</main>

--- a/src/multi-select/index.html
+++ b/src/multi-select/index.html
@@ -106,6 +106,24 @@
 				<tp-multi-select-option value="jill" label="Jill" disabled="yes">Jill</tp-multi-select-option>
 			</tp-multi-select-options>
 		</tp-multi-select>
+
+		<tp-multi-select name="names2[]" close-on-select="yes" select-all-text="All Selected">
+			<tp-multi-select-field>
+				<tp-multi-select-pills></tp-multi-select-pills>
+				<tp-multi-select-search>
+					<input placeholder="Select...">
+				</tp-multi-select-search>
+			</tp-multi-select-field>
+			<tp-multi-select-options>
+				<tp-multi-select-select-all select-text="Select All" unselect-text="Un-Select All">Select All</tp-multi-select-select-all>
+				<tp-multi-select-option value="priya" label="Priya">Priya</tp-multi-select-option>
+				<tp-multi-select-option value="varun" label="Varun">Varun</tp-multi-select-option>
+				<tp-multi-select-option value="john" label="John">John</tp-multi-select-option>
+				<tp-multi-select-option value="jane" label="Jane">Jane</tp-multi-select-option>
+				<tp-multi-select-option value="jack" label="Jack">Jack</tp-multi-select-option>
+				<tp-multi-select-option value="jill" label="Jill" disabled="yes">Jill</tp-multi-select-option>
+			</tp-multi-select-options>
+		</tp-multi-select>
 	</main>
 </body>
 </html>

--- a/src/multi-select/style.scss
+++ b/src/multi-select/style.scss
@@ -63,6 +63,10 @@ tp-multi-select-status {
 
 tp-multi-select-search {
 
+	&[active="false"] {
+		display: none;
+	}
+
 	input {
 		box-sizing: border-box;
 		border: 0;

--- a/src/multi-select/tp-multi-select-pills.ts
+++ b/src/multi-select/tp-multi-select-pills.ts
@@ -38,6 +38,11 @@ export class TPMultiSelectPillsElement extends HTMLElement {
 		this.innerHTML = text;
 	}
 
+	/**
+	 * Handle Selection Change.
+	 *
+	 * @param {CustomEvent} event Event.
+	 */
 	handleSelectionChange( event: CustomEvent ) {
 		// Get multi-select.
 		const multiSelect: TPMultiSelectElement | null = this.closest( 'tp-multi-select' );

--- a/src/multi-select/tp-multi-select-pills.ts
+++ b/src/multi-select/tp-multi-select-pills.ts
@@ -13,8 +13,47 @@ export class TPMultiSelectPillsElement extends HTMLElement {
 	 * Connected callback.
 	 */
 	connectedCallback(): void {
-		this.closest( 'tp-multi-select' )?.addEventListener( 'change', this.update.bind( this ) );
+		// Get multi-select.
+		const multiSelect: TPMultiSelectElement | null = this.closest( 'tp-multi-select' );
+		const selectAllText: string = multiSelect?.getAttribute( 'select-all-text' ) || '';
+
+		// Add pills.
+		multiSelect?.addEventListener( 'change', ( ( event: CustomEvent ) => this.handleSelectionChange( event ) ) as EventListener );
 		this.update();
+
+		// If select all text is not empty
+		if ( selectAllText ) {
+			// Update the pills markup with select all text.
+			multiSelect?.addEventListener( 'select-all', () => this.updateSelectAllText( selectAllText ) );
+			multiSelect?.addEventListener( 'unselect-all', () => this.updateSelectAllText( '' ) );
+		}
+	}
+
+	/**
+	 * Update Select All text.
+	 *
+	 * @param {string} text
+	 */
+	updateSelectAllText( text: string = '' ) {
+		this.innerHTML = text;
+	}
+
+	handleSelectionChange( event: CustomEvent ) {
+		// Get multi-select.
+		const multiSelect: TPMultiSelectElement | null = this.closest( 'tp-multi-select' );
+		const selectAllText: string = multiSelect?.getAttribute( 'select-all-text' ) || '';
+
+		/**
+		 * Only update the pills if it's not the selection all event, and
+		 * select all text is not empty.
+		 */
+		if ( selectAllText ) {
+			if ( ! event.detail?.selection ) {
+				this.update();
+			}
+		} else {
+			this.update();
+		}
 	}
 
 	/**
@@ -25,6 +64,11 @@ export class TPMultiSelectPillsElement extends HTMLElement {
 		const multiSelect: TPMultiSelectElement | null = this.closest( 'tp-multi-select' );
 		if ( ! multiSelect ) {
 			return;
+		}
+
+		// First clear the select all text.
+		if ( multiSelect.getAttribute( 'select-all-text' ) === this.textContent ) {
+			this.textContent = '';
 		}
 
 		// Determine pills.

--- a/src/multi-select/tp-multi-select-search.ts
+++ b/src/multi-select/tp-multi-select-search.ts
@@ -86,7 +86,7 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 		let matchedOptionCount = 0;
 		// Hide and show options based on search.
 		options.forEach( ( option: TPMultiSelectOptionElement ): void => {
-			if ( option.getAttribute( 'value' )?.match( new RegExp( `.*${ search.value }.*` ) ) ) {
+			if ( option.getAttribute( 'label' )?.toLowerCase().match( new RegExp( `.*${ search.value }.*` ) ) ) {
 				option.removeAttribute( 'hidden' );
 				matchedOptionCount++;
 			} else {

--- a/src/multi-select/tp-multi-select-search.ts
+++ b/src/multi-select/tp-multi-select-search.ts
@@ -86,7 +86,7 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 		let matchedOptionCount = 0;
 		// Hide and show options based on search.
 		options.forEach( ( option: TPMultiSelectOptionElement ): void => {
-			if ( option.getAttribute( 'label' )?.toLowerCase().match( new RegExp( `.*${ search.value }.*` ) ) ) {
+			if ( option.getAttribute( 'label' )?.toLowerCase().match( new RegExp( `.*${ search.value.replace( /\s/g, '.*' ) }.*` ) ) ) {
 				option.removeAttribute( 'hidden' );
 				matchedOptionCount++;
 			} else {

--- a/src/multi-select/tp-multi-select-search.ts
+++ b/src/multi-select/tp-multi-select-search.ts
@@ -33,7 +33,7 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 	 *
 	 * @param {boolean} active Active.
 	 */
-	toggleSearchInputVisibility( active = true ) {
+	toggleSearchInputVisibility( active: boolean = true ): void {
 		// Check if active is true.
 		if ( active ) {
 			// Set active attribute value to true.

--- a/src/multi-select/tp-multi-select-search.ts
+++ b/src/multi-select/tp-multi-select-search.ts
@@ -14,7 +14,8 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 	 */
 	connectedCallback(): void {
 		const input: HTMLInputElement | null = this.querySelector( 'input' );
-		if ( ! input ) {
+		const multiSelect: TPMultiSelectElement | null = this.closest( 'tp-multi-select' );
+		if ( ! input || ! multiSelect ) {
 			return;
 		}
 
@@ -22,7 +23,25 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 		input.addEventListener( 'keyup', this.handleSearchChange.bind( this ) );
 		input.addEventListener( 'input', this.handleSearchChange.bind( this ) );
 		this.addEventListener( 'click', this.handleClick.bind( this ) );
-		this.closest( 'tp-multi-select' )?.addEventListener( 'open', this.focus.bind( this ) );
+		multiSelect?.addEventListener( 'open', this.focus.bind( this ) );
+		multiSelect?.addEventListener( 'select-all', () => this.toggleSearchInputVisibility( false ) );
+		multiSelect?.addEventListener( 'unselect-all', () => this.toggleSearchInputVisibility( true ) );
+	}
+
+	/**
+	 * Toggle Search Input Visibility.
+	 *
+	 * @param {boolean} active Active.
+	 */
+	toggleSearchInputVisibility( active = true ) {
+		// Check if active is true.
+		if ( active ) {
+			// Set active attribute value to true.
+			this.setAttribute( 'active', 'true' );
+		} else {
+			// Set active attribute value to false.
+			this.setAttribute( 'active', 'false' );
+		}
 	}
 
 	/**

--- a/src/multi-select/tp-multi-select-select-all.ts
+++ b/src/multi-select/tp-multi-select-select-all.ts
@@ -51,6 +51,12 @@ export class TPMultiSelectSelectAllElement extends HTMLElement {
 			multiSelect.unSelectAll();
 			multiSelect.dispatchEvent( new CustomEvent( 'unselect-all', { bubbles: true } ) );
 		}
-		multiSelect.dispatchEvent( new CustomEvent( 'change', { bubbles: true } ) );
+
+		multiSelect.dispatchEvent( new CustomEvent( 'change', {
+			detail: {
+				selection: 'all',
+			},
+			bubbles: true,
+		} ) );
 	}
 }


### PR DESCRIPTION
- Adds a feature that when `select-all-text="Your All Selected Text Value"`  is passed as an attribute it will show that value when Select All is clicked and won't show all selected pills in the box.
<img width="439" alt="image" src="https://github.com/Travelopia/web-components/assets/11497423/64ac6170-08aa-48ab-afda-5d2a44c9c86e">
- If this attribute value is not passed then it will add all pills.
<img width="420" alt="image" src="https://github.com/Travelopia/web-components/assets/11497423/7360a9f5-e262-4cf9-ae0b-e77fdcbadc20">

- Fixes the search issue. It was searching by value instead of label and space had to be accounted for in the search value.
