### PR TITLE
Update Multi-Select Component Search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travelopia/web-components",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Accessible web components for the modern web",
   "files": [
     "dist"

--- a/src/multi-select/tp-multi-select-search.ts
+++ b/src/multi-select/tp-multi-select-search.ts
@@ -112,6 +112,10 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 	 * Set focus on the search field.
 	 */
 	focus(): void {
+		// When it's focused, use search change to ensure the results are refreshed.
+		this.handleSearchChange();
+
+		// Focus on input.
 		this.querySelector( 'input' )?.focus();
 	}
 }


### PR DESCRIPTION
- When the user selected an option after a search, the search results were not getting refreshed (to show all options)and were still showing the old results.
- When the options are opened, ensure we get fresh results.