### PR TITLE
Fix Slider Component CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travelopia/web-components",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Accessible web components for the modern web",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travelopia/web-components",
-  "version": "0.6.0",
+  "version": "0.5.10",
   "description": "Accessible web components for the modern web",
   "files": [
     "dist"

--- a/src/slider/style.scss
+++ b/src/slider/style.scss
@@ -62,6 +62,7 @@ tp-slider[behaviour="fade"] {
 		> tp-slider-slide[active="yes"] {
 			visibility: visible;
 			opacity: 1;
+			z-index: 1;
 		}
 	}
 }


### PR DESCRIPTION
- When using fade mode of the slider, the adding hover state on the selected slider does not work because of the z-index issue.
- This PR fixes the z-index issue by giving a high z-index to the selected slide.