### PR TITLE
TPSlider: Fix slider arrows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travelopia/web-components",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "Accessible web components for the modern web",
   "files": [
     "dist"

--- a/src/slider/index.html
+++ b/src/slider/index.html
@@ -130,7 +130,7 @@
 		</tp-slider>
 
 		<!--Nested sliders-->
-		<tp-slider flexible-height="yes" infinite="yes" swipe="yes" behaviour="fade">
+		<tp-slider flexible-height="yes" swipe="yes" behaviour="fade">
 			<tp-slider-arrow direction="previous"><button>&laquo; Previous</button></tp-slider-arrow>
 			<tp-slider-arrow direction="next"><button>Next &raquo;</button></tp-slider-arrow>
 			<tp-slider-track>

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -215,6 +215,37 @@ export class TPSliderElement extends HTMLElement {
 	}
 
 	/**
+	 * Get the arrow element by selector.
+	 *
+	 * In case of nested sliders, it difficult to find the correct arrow
+	 * because arrows can be placed anywhere.
+	 * This function checks if the parent tp-slider belongs to this component,
+	 * then return that arrow element, using 'this'.
+	 *
+	 * @param {String} selector Selector.
+	 */
+	getArrow( selector: string ) {
+		// Get all arrows.
+		const arrows: NodeListOf<TPSliderArrowElement> | null = this.querySelectorAll( selector );
+		const parentSliderElement: TPSliderElement = this;
+		let theArrow: TPSliderArrowElement | null = this.querySelector( selector );
+
+		// Loop through all the arrows including the one's inside nested slider.
+		arrows.forEach( ( arrow ) => {
+			/**
+			 * If the closest tp-slider is the same as the parentSliderElement, that means we have found
+			 * the correct arrow.
+			 */
+			if ( parentSliderElement === arrow.closest( 'tp-slider' ) ) {
+				theArrow = arrow;
+			}
+		} );
+
+		// Return arrow.
+		return theArrow;
+	}
+
+	/**
 	 * Update stuff when any attribute has changed.
 	 * Example: Update subcomponents.
 	 */
@@ -222,8 +253,8 @@ export class TPSliderElement extends HTMLElement {
 		// Get subcomponents.
 		const sliderNavItems: NodeListOf<TPSliderNavItemElement> | null = this.querySelectorAll( 'tp-slider-nav-item' );
 		const sliderCounts: NodeListOf<TPSliderCountElement> | null = this.querySelectorAll( 'tp-slider-count' );
-		const leftArrow: TPSliderArrowElement | null = this.querySelector( 'tp-slider-arrow[direction="previous"]' );
-		const rightArrow: TPSliderArrowElement | null = this.querySelector( 'tp-slider-arrow[direction="next"]' );
+		const leftArrow: TPSliderArrowElement | null = this.getArrow( 'tp-slider-arrow[direction="previous"]' );
+		const rightArrow: TPSliderArrowElement | null = this.getArrow( 'tp-slider-arrow[direction="next"]' );
 
 		// Set active slide.
 		const slides: NodeListOf<TPSliderSlideElement> | null | undefined = this.getSlideElements();

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -222,7 +222,7 @@ export class TPSliderElement extends HTMLElement {
 	 * This function checks if the parent tp-slider belongs to this component,
 	 * then return that arrow element, using 'this'.
 	 *
-	 * @param {String} selector Selector.
+	 * @param {string} selector Selector.
 	 */
 	getArrow( selector: string ) {
 		// Get all arrows.


### PR DESCRIPTION
- The disabled attribute was not working in the case of the nested slider because since querySelector was used it would find the first instance of the arrow which was from the inner slider instead of parent slider arrow.
- This PR fixes that issue by checking if the parent `tp-slider` of the arrow element is same as `this`. If it is then that means we have found the correct arrow element.
- we cannot use CSS for this because the user can keep the arrows anywhere they want.

<img width="279" alt="image" src="https://github.com/Travelopia/web-components/assets/11497423/f52ea425-c45a-46c5-bd9b-5d6d98daeec4">
<img width="1054" alt="image" src="https://github.com/Travelopia/web-components/assets/11497423/c120096d-cba2-4d20-8106-108a1ee3c054">
