### PR TITLE
Fix duplicate event listeners in multi-select component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@travelopia/web-components",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@travelopia/web-components",
-      "version": "0.5.15",
+      "version": "0.5.16",
       "license": "MIT",
       "devDependencies": {
         "@wordpress/eslint-plugin": "^17.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travelopia/web-components",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "Accessible web components for the modern web",
   "files": [
     "dist"

--- a/src/multi-select/tp-multi-select-field.ts
+++ b/src/multi-select/tp-multi-select-field.ts
@@ -8,9 +8,22 @@ import { TPMultiSelectElement } from './tp-multi-select';
  */
 export class TPMultiSelectFieldElement extends HTMLElement {
 	/**
+	 * Properties.
+	 */
+	private initialized: boolean = false;
+
+	/**
 	 * Connected callback.
 	 */
 	connectedCallback(): void {
+		// Return early if already initialized.
+		if ( true === this.initialized ) {
+			return;
+		}
+
+		// Set initialized flag to true.
+		this.initialized = true;
+
 		this.addEventListener( 'click', this.toggleOpen.bind( this ) );
 	}
 

--- a/src/multi-select/tp-multi-select-option.ts
+++ b/src/multi-select/tp-multi-select-option.ts
@@ -8,9 +8,22 @@ import { TPMultiSelectElement } from './tp-multi-select';
  */
 export class TPMultiSelectOptionElement extends HTMLElement {
 	/**
+	 * Properties.
+	 */
+	private initialized: boolean = false;
+
+	/**
 	 * Connected callback.
 	 */
 	connectedCallback(): void {
+		// Return early if already initialized.
+		if ( true === this.initialized ) {
+			return;
+		}
+
+		// Set initialized flag to true.
+		this.initialized = true;
+
 		this.addEventListener( 'click', this.toggle.bind( this ) );
 	}
 


### PR DESCRIPTION
When re-attaching the `multi-select` component inside the DOM, the `connectedCallback` of the components run again and duplicate event listeners are added to the component.

To fix this add a check in the `connectedCallback` that - "if the component is already initialized don't add the event listeners again.

Reference issue - https://github.com/Travelopia/web-components/issues/35