### PR TITLE
Remove the click handler on multi-select search sub-component

### DIFF
--- a/src/multi-select/index.html
+++ b/src/multi-select/index.html
@@ -106,6 +106,24 @@
 				<tp-multi-select-option value="jill" label="Jill" disabled="yes">Jill</tp-multi-select-option>
 			</tp-multi-select-options>
 		</tp-multi-select>
+
+		<tp-multi-select name="names3[]" close-on-select="yes">
+			<tp-multi-select-field>
+				<tp-multi-select-pills></tp-multi-select-pills>
+				<tp-multi-select-search>
+					<input placeholder="Select...">
+				</tp-multi-select-search>
+			</tp-multi-select-field>
+			<tp-multi-select-options>
+				<tp-multi-select-select-all select-text="Select All" unselect-text="Un-Select All">Select All</tp-multi-select-select-all>
+				<tp-multi-select-option value="priya" label="Priya">Priya</tp-multi-select-option>
+				<tp-multi-select-option value="varun" label="Varun">Varun</tp-multi-select-option>
+				<tp-multi-select-option value="john" label="John">John</tp-multi-select-option>
+				<tp-multi-select-option value="jane" label="Jane">Jane</tp-multi-select-option>
+				<tp-multi-select-option value="jack" label="Jack">Jack</tp-multi-select-option>
+				<tp-multi-select-option value="jill" label="Jill" disabled="yes">Jill</tp-multi-select-option>
+			</tp-multi-select-options>
+		</tp-multi-select>
 	</main>
 </body>
 </html>

--- a/src/multi-select/tp-multi-select-search.ts
+++ b/src/multi-select/tp-multi-select-search.ts
@@ -21,7 +21,6 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 		input.addEventListener( 'keydown', this.handleKeyboardInputs.bind( this ) );
 		input.addEventListener( 'keyup', this.handleSearchChange.bind( this ) );
 		input.addEventListener( 'input', this.handleSearchChange.bind( this ) );
-		this.addEventListener( 'click', this.handleClick.bind( this ) );
 		this.closest( 'tp-multi-select' )?.addEventListener( 'open', this.focus.bind( this ) );
 	}
 
@@ -84,17 +83,6 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 		}
 
 		multiSelect.setAttribute( 'visible-options', matchedOptionCount.toString() );
-	}
-
-	/**
-	 * Handle click.
-	 *
-	 * @param {Event} e Click event.
-	 */
-	protected handleClick( e: Event ): void {
-		e.preventDefault();
-		e.stopPropagation();
-		this.closest( 'tp-multi-select' )?.setAttribute( 'open', 'yes' );
 	}
 
 	/**


### PR DESCRIPTION
**Problem:**

Suppose you have two multi-select input fields, both with search input fields.
Now you click on one of them and its dropdown opens. Now suppose you click on another one's search, then its dropdown opens, but the previous ones dropdown doesn't close.

https://prnt.sc/iQUv9gVkzjNq

**Reason:**

That's because we have an event listener attached to the search sub-component, which stops the event propagation.
But for closing any dropdown, we have event listeners attached to the document.
So, if we click on the search sub-component, the event doesn't reaches to the document and thus the dropdown doesn't close.

**Solution:**

We already have an event listener attached to the field sub-component, so we don't need another event listener on the search sub-component.
Although I have tested this and seems like removing this doesn't affect anything and everything works fine, but if we don't want to remove this event listener I have another solution which I have mentioned in a comment below.