### PR TITLE
Fix: Multi-Select Cross Browser Pill Remove

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@travelopia/web-components",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@travelopia/web-components",
-      "version": "0.5.19",
+      "version": "0.5.20",
       "license": "MIT",
       "devDependencies": {
         "@wordpress/eslint-plugin": "^17.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@travelopia/web-components",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@travelopia/web-components",
-      "version": "0.5.20",
+      "version": "0.5.21",
       "license": "MIT",
       "devDependencies": {
         "@wordpress/eslint-plugin": "^17.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travelopia/web-components",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Accessible web components for the modern web",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travelopia/web-components",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "Accessible web components for the modern web",
   "files": [
     "dist"

--- a/src/multi-select/index.html
+++ b/src/multi-select/index.html
@@ -93,7 +93,7 @@
 			<tp-multi-select-field>
 				<tp-multi-select-pills></tp-multi-select-pills>
 				<tp-multi-select-search>
-					<input placeholder="Select...">
+					<input type="text" placeholder="Select...">
 				</tp-multi-select-search>
 			</tp-multi-select-field>
 			<tp-multi-select-options>

--- a/src/multi-select/tp-multi-select-pill.ts
+++ b/src/multi-select/tp-multi-select-pill.ts
@@ -16,21 +16,12 @@ export class TPMultiSelectPillElement extends HTMLElement {
 	/**
 	 * Handle button click.
 	 *
-	 * @param {any} e Click event.
+	 * @param {Event} e Click event.
 	 */
-	handleButtonClick( e: any | null ): void {
+	handleButtonClick( e: Event | null ): void {
 		e?.preventDefault();
 		e?.stopPropagation();
-
-		/**
-		 * If the event has a clientX greater than 0, then it is a genuine click event.
-		 * Only then we remove pill.
-		 * This will ensure, it will not get fired when the enter button is pressed.
-		 * We do this so that it does not remove the pills when enter button is pressed.
-		 */
-		if ( e?.clientX ?? 0 > 0 ) {
-			this.removePill();
-		}
+		this.removePill();
 	}
 
 	/**

--- a/src/multi-select/tp-multi-select-pill.ts
+++ b/src/multi-select/tp-multi-select-pill.ts
@@ -23,12 +23,12 @@ export class TPMultiSelectPillElement extends HTMLElement {
 		e?.stopPropagation();
 
 		/**
-		 * If the event is has a pointerType, which means it's a mouse event or touch event
+		 * If the event has a clientX greater than 0, then it is a genuine click event.
 		 * Only then we remove pill.
-		 * This will ensure, it will not get fired when a enter button is pressed.
+		 * This will ensure, it will not get fired when the enter button is pressed.
 		 * We do this so that it does not remove the pills when enter button is pressed.
 		 */
-		if ( e?.pointerType ) {
+		if ( e?.clientX ?? 0 > 0 ) {
 			this.removePill();
 		}
 	}

--- a/src/multi-select/tp-multi-select-pills.ts
+++ b/src/multi-select/tp-multi-select-pills.ts
@@ -67,7 +67,7 @@ export class TPMultiSelectPillsElement extends HTMLElement {
 			newPill.setAttribute( 'value', pillValue );
 			newPill.innerHTML = `
 			<span>${ multiSelectOption.getAttribute( 'label' ) ?? '' }</span>
-			<button>x</button>
+			<button type="button">x</button>
 			`;
 			this.appendChild( newPill );
 		} );

--- a/src/multi-select/tp-multi-select-search.ts
+++ b/src/multi-select/tp-multi-select-search.ts
@@ -38,6 +38,9 @@ export class TPMultiSelectSearchElement extends HTMLElement {
 		}
 
 		switch ( e.key ) {
+			case 'Enter':
+				e.preventDefault(); // Prevent inadvertent form submits.
+				break;
 			case 'ArrowDown':
 				multiSelect.setAttribute( 'open', 'yes' );
 				break;


### PR DESCRIPTION
Cross-browser solution to remove pills correctly without submitting the form.

Fixes issues introduced in https://github.com/Travelopia/web-components/releases/tag/0.5.18