### PR TITLE
Fix: TP Slider Swipe Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travelopia/web-components",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Accessible web components for the modern web",
   "files": [
     "dist"

--- a/src/slider/README.md
+++ b/src/slider/README.md
@@ -62,6 +62,7 @@ slider.setCurrentSlide( 2 );
 | auto-slide-interval | No       | <interval>            | Interval in milliseconds.                                                                                       |
 | per-view            | No       | <per-view>            | Handles slider behavior having more than 1 slides. No. of slides to show in one view. Default value is 1.       |
 | step                | No       | <step>                | Steps number of slides on next and previous transition. No. of slides to step to at a time. Default value is 1. |
+| swipe-threshold     | No       | `200`                 | It will not swipe if the swipe value is more than this number. Default value is 200.                            |
 | responsive          | No       | <responsive-settings> | Responsive settings to be passed in a JSON string format.                                                       |
 
 * `responsive` attribute value data shape.

--- a/src/slider/index.html
+++ b/src/slider/index.html
@@ -33,7 +33,7 @@
 <body>
 	<main>
 		<!--Slider that slides horizontally with responsive settings.-->
-		<tp-slider flexible-height="yes" infinite="yes" swipe="yes" responsive='[{"media":"(min-width: 600px)","flexible-height":"yes","infinite":"no","swipe":"yes","auto-slide-interval":2000,"per-view":1,"step":2},{"media":"(min-width: 300px)","flexible-height":"yes","infinite":"no","swipe":"yes","behaviour":"fade","auto-slide-interval":2000,"per-view":1,"step":1}]'>
+		<tp-slider swipe-threshold="210" flexible-height="yes" infinite="yes" swipe="yes" responsive='[{"media":"(min-width: 600px)","flexible-height":"yes","infinite":"no","swipe":"yes","auto-slide-interval":2000,"per-view":1,"step":2},{"media":"(min-width: 300px)","flexible-height":"yes","infinite":"no","swipe":"yes","behaviour":"fade","auto-slide-interval":2000,"per-view":1,"step":1}]'>
 			<tp-slider-arrow direction="previous"><button>&laquo; Previous</button></tp-slider-arrow>
 			<tp-slider-arrow direction="next"><button>Next &raquo;</button></tp-slider-arrow>
 			<tp-slider-track>

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -15,6 +15,8 @@ export class TPSliderElement extends HTMLElement {
 	 * Properties.
 	 */
 	protected touchStartX: number = 0;
+	protected touchStartY: number = 0;
+	protected swipeThreshold: number = 200;
 	protected responsiveSettings: { [ key: string ]: any };
 	protected allowedResponsiveKeys: string[] = [
 		'flexible-height',
@@ -37,6 +39,9 @@ export class TPSliderElement extends HTMLElement {
 		if ( ! this.getAttribute( 'current-slide' ) ) {
 			this.setAttribute( 'current-slide', '1' );
 		}
+
+		// Threshold Setting.
+		this.swipeThreshold = Number( this?.getAttribute( 'swipe-threshold' ) ?? '200' );
 
 		// Initialize slider.
 		this.slide();
@@ -512,6 +517,7 @@ export class TPSliderElement extends HTMLElement {
 	protected handleTouchStart( e: TouchEvent ): void {
 		if ( 'yes' === this.getAttribute( 'swipe' ) ) {
 			this.touchStartX = e.touches[ 0 ].clientX;
+			this.touchStartY = e.touches[ 0 ].clientY;
 		}
 	}
 
@@ -527,13 +533,31 @@ export class TPSliderElement extends HTMLElement {
 			return;
 		}
 
+		// Calculate the horizontal and vertical distance moved.
 		const touchEndX: number = e.changedTouches[ 0 ].clientX;
-		const swipeDistance: number = touchEndX - this.touchStartX;
+		const touchEndY: number = e.changedTouches[ 0 ].clientY;
+		const swipeDistanceX: number = touchEndX - this.touchStartX;
+		const swipeDistanceY: number = touchEndY - this.touchStartY;
 
-		if ( swipeDistance > 0 ) {
-			this.previous();
-		} else if ( swipeDistance < 0 ) {
-			this.next();
+		// Determine if the swipe is predominantly horizontal or vertical.
+		const isHorizontalSwipe = Math.abs( swipeDistanceX ) > Math.abs( swipeDistanceY );
+
+		// If it's not horizontal swipe, return
+		if ( ! isHorizontalSwipe ) {
+			return;
+		}
+
+		// Check if it's a right or left swipe.
+		if ( swipeDistanceX > 0 ) {
+			// Right-Swipe: Check if horizontal swipe distance is less than the threshold.
+			if ( swipeDistanceX < this.swipeThreshold ) {
+				this.previous();
+			}
+		} else if ( swipeDistanceX < 0 ) {
+			// Left-Swipe: Check if horizontal swipe distance is less than the threshold.
+			if ( swipeDistanceX < -this.swipeThreshold ) {
+				this.next();
+			}
 		}
 	}
 

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -540,7 +540,7 @@ export class TPSliderElement extends HTMLElement {
 		const swipeDistanceY: number = touchEndY - this.touchStartY;
 
 		// Determine if the swipe is predominantly horizontal or vertical.
-		const isHorizontalSwipe = Math.abs( swipeDistanceX ) > Math.abs( swipeDistanceY );
+		const isHorizontalSwipe: boolean = Math.abs( swipeDistanceX ) > Math.abs( swipeDistanceY );
 
 		// If it's not horizontal swipe, return
 		if ( ! isHorizontalSwipe ) {


### PR DESCRIPTION
**Issue:** The slider moves to the next/prev slide when the user scrolls vertically.

This PR adds feature to move the slides only if it's a horizontal scroll and in-case if the user swipes diagonally, we have a threshold after which it will not move the slide.