### PR TITLE
Add form reference attribute to tp-multi-select

### DIFF
--- a/src/multi-select/README.md
+++ b/src/multi-select/README.md
@@ -88,9 +88,10 @@ const value = multiSelect.value;
 
 | Attribute       | Required | Values                   | Notes                                                                               |
 |-----------------|----------|--------------------------|-------------------------------------------------------------------------------------|
-| name            | Yes      | <name of the form field> | Whether the height of the slider changes depending on the content inside the slides |
+| name            | Yes      | \<name of the form field\> | The name that is given to the form field. |
 | multiple        | No       | `yes`, `no`               | Whether the field needs to be a single or mult-select form field. Yes by default    |
 | close-on-select | No       | `yes`                    | Whether to close the options when a value is selected                               |
+| form | No | \<id of the form\> | The id of the form with which the select input will be linked and submitted. |
 
 ## Events
 

--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -198,6 +198,7 @@ export class TPMultiSelectElement extends HTMLElement {
 		if ( ! selectElement ) {
 			selectElement = document.createElement( 'select' );
 			selectElement.setAttribute( 'name', this.getAttribute( 'name' ) ?? '' );
+			selectElement.setAttribute( 'form', this.getAttribute( 'form' ) ?? '' );
 
 			if ( 'no' !== this.getAttribute( 'multiple' ) ) {
 				selectElement.setAttribute( 'multiple', 'multiple' );


### PR DESCRIPTION
Added `form` attribute to the `tp-multi-select` component to add ability to link it with a form without using JavaScript.