### PR TITLE
Fix Swipe Condition of Next Slide

### DIFF
--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -555,7 +555,7 @@ export class TPSliderElement extends HTMLElement {
 			}
 		} else if ( swipeDistanceX < 0 ) {
 			// Left-Swipe: Check if horizontal swipe distance is less than the threshold.
-			if ( swipeDistanceX < -this.swipeThreshold ) {
+			if ( swipeDistanceX > -this.swipeThreshold ) {
 				this.next();
 			}
 		}


### PR DESCRIPTION
## Current Issue
The default value of `swipeThreshold` is 200. Because of an incorrect check for the next swipe, the user has to scroll more than the threshold value to swipe to the next slide.

## Fix
The condition has to be reversed because `swipeDistanceX` will be negative in case of the next slide swipe.