### PR TITLE
Fix Multi-select Pill Remove 

### DIFF
--- a/src/multi-select/tp-multi-select-pills.ts
+++ b/src/multi-select/tp-multi-select-pills.ts
@@ -65,13 +65,35 @@ export class TPMultiSelectPillsElement extends HTMLElement {
 				return;
 			}
 
-			const newPill: HTMLElement = document.createElement( 'tp-multi-select-pill' );
-			newPill.setAttribute( 'value', pillValue );
-			newPill.innerHTML = `
-			<span>${ multiSelectOption.getAttribute( 'label' ) ?? '' }</span>
-			<button type="button">x</button>
-			`;
-			this.appendChild( newPill );
+			this.appendChild( this.createPill( pillValue, multiSelectOption.getAttribute( 'label' ) ?? '' ) );
 		} );
+	}
+
+	/**
+	 * Create a new pill.
+	 *
+	 * @param {string} value Pill value.
+	 * @param {string} label Pill label.
+	 *
+	 * @return {TPMultiSelectPillElement} New pill.
+	 */
+	createPill( value: string, label: string ): TPMultiSelectPillElement {
+		const newPill = document.createElement( 'tp-multi-select-pill' ) as TPMultiSelectPillElement;
+		newPill.setAttribute( 'value', value );
+
+		const pillLabel: HTMLElement = document.createElement( 'span' );
+		pillLabel.textContent = label;
+
+		const pillCloseButton: HTMLElement = document.createElement( 'button' );
+		pillCloseButton.setAttribute( 'type', 'button' );
+		pillCloseButton.textContent = 'x';
+		pillCloseButton.addEventListener( 'click', () => {
+			newPill.removePill();
+		} );
+
+		newPill.appendChild( pillLabel );
+		newPill.appendChild( pillCloseButton );
+
+		return newPill;
 	}
 }


### PR DESCRIPTION
## Description

The pill removal button isn't working because the `addEventListener` added to the remove button in `tp-multi-select-pill` is added in the `constructor` instead of `connectedCallback`. The constructor is called when the pill is created, but that instance doesn't include the remove button as a child. As a result, no `addEventListener` is attached to the pill remove button.

## Solutions

I see two possible solutions:

- [ ] Move the `addEventListener` code to the `connectedCallback`. But the other web components don't follow this and all the `addEventListener` are added directly to the `constructor`. To keep it consistent I followed the second approach
- [x] Attach the event listener to the button manually while creating the pill element.