### PR TITLE
Fix: Form reference bug in tp-multi-select

### DIFF
--- a/src/multi-select/tp-multi-select.ts
+++ b/src/multi-select/tp-multi-select.ts
@@ -199,6 +199,12 @@ export class TPMultiSelectElement extends HTMLElement {
 			selectElement = document.createElement( 'select' );
 			selectElement.setAttribute( 'name', this.getAttribute( 'name' ) ?? '' );
 
+			const formReference = this.getAttribute( 'form' );
+
+			if ( formReference ) {
+				selectElement.setAttribute( 'form', formReference );
+			}
+
 			if ( 'no' !== this.getAttribute( 'multiple' ) ) {
 				selectElement.setAttribute( 'multiple', 'multiple' );
 			}


### PR DESCRIPTION
The input value will not get included in form submission if the form attribute is an empty string. Fixing this requires checking the attribute to see if it is empty or not.