### PR TITLE
feat: Getter function for Current Tab

### DIFF
--- a/src/tabs/README.md
+++ b/src/tabs/README.md
@@ -21,11 +21,11 @@ import '@travelopia/web-components/dist/tabs';
 import '@travelopia/web-components/dist/tabs/style.css';
 
 // TypeScript usage:
-import { TPTabs } from '@travelopia/web-components';
+import { TPTabsElement } from '@travelopia/web-components';
 
 ...
 
-const tabs: TPTabs = document.querySelector( 'tp-tabs' );
+const tabs: TPTabsElement = document.querySelector( 'tp-tabs' );
 tabs.setCurrentTab( 'overview' );
 ```
 

--- a/src/tabs/tp-tabs.ts
+++ b/src/tabs/tp-tabs.ts
@@ -60,7 +60,7 @@ export class TPTabsElement extends HTMLElement {
 	 */
 	update(): void {
 		// Get current tab.
-		const currentTab: string = this.getAttribute( 'current-tab' ) ?? '';
+		const currentTab: string = this.currentTab;
 
 		// Check if current tab exists.
 		if ( ! this.querySelector( `tp-tabs-tab[id="${ currentTab }"]` ) ) {
@@ -114,6 +114,16 @@ export class TPTabsElement extends HTMLElement {
 
 		// Set current associated tab.
 		this.setCurrentTab();
+	}
+
+	/**
+	 * Get current tab.
+	 *
+	 * @return {string} Current tab ID.
+	 */
+	get currentTab(): string {
+		// Return the current tab ID.
+		return this.getAttribute( 'current-tab' ) ?? '';
 	}
 
 	/**


### PR DESCRIPTION
Addresses #9 

- Instead of a function, added a getter function. therefore, it could be accessed as a property of the component.
- Ex: `tpTabs.currentTab`