### PR TITLE
Fix: Handle missing getTotalSlides method in slider

### DIFF
--- a/src/slider/index.ts
+++ b/src/slider/index.ts
@@ -18,8 +18,8 @@ import { TPSliderCountElement } from './tp-slider-count';
 /**
  * Register Components.
  */
-customElements.define( 'tp-slider-count', TPSliderCountElement );
 customElements.define( 'tp-slider', TPSliderElement );
+customElements.define( 'tp-slider-count', TPSliderCountElement );
 customElements.define( 'tp-slider-track', TPSliderTrackElement );
 customElements.define( 'tp-slider-slides', TPSliderSlidesElement );
 customElements.define( 'tp-slider-slide', TPSliderSlideElement );


### PR DESCRIPTION
Fixes #86 

## Current Issue
- The update method in the tp-slider-count component throws a TypeError: e.getTotalSlides is not a function. This occurs because the getTotalSlides method is being called on a tp-slider element before the required JavaScript for the slider has been loaded, leading to the method being undefined at the time of invocation.
![image](https://github.com/user-attachments/assets/bf83f46d-82f8-4c02-a1fc-075a80d749f0)


## Fix
- This PR resolves the issue by ensuring the necessary JavaScript for the tp-slider component is loaded and initialized before any method calls are made. 