### PR TITLE
WP-184 Navigation items current state and white space after last slide

### DIFF
--- a/src/slider/tp-slider-nav-item.ts
+++ b/src/slider/tp-slider-nav-item.ts
@@ -59,7 +59,7 @@ export class TPSliderNavItemElement extends HTMLElement {
 		const currentSlideNavItem = Array.from( slideNav?.children ?? [] ).indexOf( this );
 
 		// Check if the nav dot is equal to total slides groups.
-		if ( currentSlideNavItem + 1 === this.slider?.totalSlidesGroups() ) {
+		if ( currentSlideNavItem + 1 === this.slider?.getTotalSlidesGroupCount() ) {
 			// Return last posible slide group.
 			return this.slider?.getTotalSlides() - step + 1;
 		}

--- a/src/slider/tp-slider-nav-item.ts
+++ b/src/slider/tp-slider-nav-item.ts
@@ -53,9 +53,18 @@ export class TPSliderNavItemElement extends HTMLElement {
 
 		// No, find it in the navigation.
 		const slideNav: TPSliderNavElement | null = this.closest( 'tp-slider-nav' );
-		const step = this.slider?.step;
+		const step = this.slider?.step || 1;
+
+		// current dot position.
+		const currentSlideNavItem = Array.from( slideNav?.children ?? [] ).indexOf( this );
+
+		// Check if the nav dot is equal to total slides groups.
+		if ( currentSlideNavItem + 1 === this.slider?.totalSlidesGroups() ) {
+			// Return last posible slide group.
+			return this.slider?.getTotalSlides() - step + 1;
+		}
 
 		// Return index of this element considering the step value.
-		return ( Array.from( slideNav?.children ?? [] ).indexOf( this ) * ( step ?? 1 ) ) + 1;
+		return ( currentSlideNavItem * step ) + 1;
 	}
 }

--- a/src/slider/tp-slider-nav-item.ts
+++ b/src/slider/tp-slider-nav-item.ts
@@ -55,9 +55,10 @@ export class TPSliderNavItemElement extends HTMLElement {
 		const slideNav: TPSliderNavElement | null = this.closest( 'tp-slider-nav' );
 		const step = this.slider?.step || 1;
 
-		const any: number  = Math.min(( (this.slider?.getTotalSlides() ?? 1) - (this.slider?.perView ?? 1) ) + 1, ( Array.from( slideNav?.children ?? [] ).indexOf( this ) * ( step ?? 1 ) ) + 1);
+		// Get Current slide number.
+		const currentSlideIndex: number = Math.min( ( ( this.slider?.getTotalSlides() ?? 1 ) - ( this.slider?.perView ?? 1 ) ) + 1, ( Array.from( slideNav?.children ?? [] ).indexOf( this ) * ( step ?? 1 ) ) + 1 );
 
 		// Return index of this element considering the step value.
-		return any;
+		return currentSlideIndex;
 	}
 }

--- a/src/slider/tp-slider-nav-item.ts
+++ b/src/slider/tp-slider-nav-item.ts
@@ -55,16 +55,9 @@ export class TPSliderNavItemElement extends HTMLElement {
 		const slideNav: TPSliderNavElement | null = this.closest( 'tp-slider-nav' );
 		const step = this.slider?.step || 1;
 
-		// current dot position.
-		const currentSlideNavItem = Array.from( slideNav?.children ?? [] ).indexOf( this );
-
-		// Check if the nav dot is equal to total slides groups.
-		if ( currentSlideNavItem + 1 === this.slider?.getTotalSlidesGroupCount() ) {
-			// Return last posible slide group.
-			return this.slider?.getTotalSlides() - step + 1;
-		}
+		const any: number  = Math.min(( (this.slider?.getTotalSlides() ?? 1) - (this.slider?.perView ?? 1) ) + 1, ( Array.from( slideNav?.children ?? [] ).indexOf( this ) * ( step ?? 1 ) ) + 1);
 
 		// Return index of this element considering the step value.
-		return ( currentSlideNavItem * step ) + 1;
+		return any;
 	}
 }

--- a/src/slider/tp-slider-nav.ts
+++ b/src/slider/tp-slider-nav.ts
@@ -36,11 +36,10 @@ export class TPSliderNavElement extends HTMLElement {
 		}
 
 		// Total slides.
-		const step = Number( this.slider?.getAttribute( 'step' ) ? Number( this.slider?.getAttribute( 'per-view' ) ?? '1' ) : 1 );
-		const totalSlides = Number( this.slider?.getAttribute( 'total' ) ?? 0 );
+		const totalSlides: number = this.slider?.getTotalSlides();
 
 		// Calculate the number of navigation items.
-		const totalNavItems = Math.ceil( totalSlides / step );
+		const totalNavItems: number = this.slider?.perView > this.slider?.step ? Math.ceil((totalSlides - this.slider?.perView) / this.slider?.step) + 1 : this.slider?.totalSlidesGroups();
 
 		// Clear the navigation.
 		this.innerHTML = '';

--- a/src/slider/tp-slider-nav.ts
+++ b/src/slider/tp-slider-nav.ts
@@ -39,16 +39,7 @@ export class TPSliderNavElement extends HTMLElement {
 		const totalSlides: number = this.slider?.getTotalSlides();
 
 		// Initialise the total number of navigation items.
-		let totalNavItems: number;
-
-		// Update the total number of navigation items based on the slider's step and perView. considering perView can not be grater than the step. As if perView is greater than step, then we end up with hiding some slides on each shift.
-		if ( this.slider?.perView > this.slider?.step ) {
-			// Scenario 1: If the slider's step is less than the number of slides per view, we need to calculate the total number of navigation items.
-			totalNavItems = Math.ceil( ( totalSlides - this.slider?.perView ) / this.slider?.step ) + 1;
-		} else {
-			// Scenario 2: we can create nav items equal to number of slides group.
-			totalNavItems = this.slider?.getTotalSlidesGroupCount();
-		}
+		const totalNavItems: number = Math.ceil( ( totalSlides - this.slider?.perView ) / this.slider?.step ) + 1;
 
 		// Clear the navigation.
 		this.innerHTML = '';

--- a/src/slider/tp-slider-nav.ts
+++ b/src/slider/tp-slider-nav.ts
@@ -39,7 +39,7 @@ export class TPSliderNavElement extends HTMLElement {
 		const totalSlides: number = this.slider?.getTotalSlides();
 
 		// Calculate the number of navigation items.
-		const totalNavItems: number = this.slider?.perView > this.slider?.step ? Math.ceil( ( totalSlides - this.slider?.perView ) / this.slider?.step ) + 1 : this.slider?.totalSlidesGroups();
+		const totalNavItems: number = this.slider?.perView > this.slider?.step ? Math.ceil( ( totalSlides - this.slider?.perView ) / this.slider?.step ) + 1 : this.slider?.getTotalSlidesGroupCount();
 
 		// Clear the navigation.
 		this.innerHTML = '';

--- a/src/slider/tp-slider-nav.ts
+++ b/src/slider/tp-slider-nav.ts
@@ -39,7 +39,7 @@ export class TPSliderNavElement extends HTMLElement {
 		const totalSlides: number = this.slider?.getTotalSlides();
 
 		// Calculate the number of navigation items.
-		const totalNavItems: number = this.slider?.perView > this.slider?.step ? Math.ceil((totalSlides - this.slider?.perView) / this.slider?.step) + 1 : this.slider?.totalSlidesGroups();
+		const totalNavItems: number = this.slider?.perView > this.slider?.step ? Math.ceil( ( totalSlides - this.slider?.perView ) / this.slider?.step ) + 1 : this.slider?.totalSlidesGroups();
 
 		// Clear the navigation.
 		this.innerHTML = '';

--- a/src/slider/tp-slider-nav.ts
+++ b/src/slider/tp-slider-nav.ts
@@ -42,8 +42,8 @@ export class TPSliderNavElement extends HTMLElement {
 		let totalNavItems: number;
 
 		// Update the total number of navigation items based on the slider's step and perView. considering perView can not be grater than the step. As if perView is greater than step, then we end up with hiding some slides on each shift.
-		// Scenario 1: If the slider's step is less than the number of slides per view, we need to calculate the total number of navigation items.
 		if ( this.slider?.perView > this.slider?.step ) {
+			// Scenario 1: If the slider's step is less than the number of slides per view, we need to calculate the total number of navigation items.
 			totalNavItems = Math.ceil( ( totalSlides - this.slider?.perView ) / this.slider?.step ) + 1;
 		} else {
 			// Scenario 2: we can create nav items equal to number of slides group.

--- a/src/slider/tp-slider-nav.ts
+++ b/src/slider/tp-slider-nav.ts
@@ -38,8 +38,17 @@ export class TPSliderNavElement extends HTMLElement {
 		// Total slides.
 		const totalSlides: number = this.slider?.getTotalSlides();
 
-		// Calculate the number of navigation items.
-		const totalNavItems: number = this.slider?.perView > this.slider?.step ? Math.ceil( ( totalSlides - this.slider?.perView ) / this.slider?.step ) + 1 : this.slider?.getTotalSlidesGroupCount();
+		// Initialise the total number of navigation items.
+		let totalNavItems: number;
+
+		// Update the total number of navigation items based on the slider's step and perView. considering perView can not be grater than the step. As if perView is greater than step, then we end up with hiding some slides on each shift.
+		// Scenario 1: If the slider's step is less than the number of slides per view, we need to calculate the total number of navigation items.
+		if ( this.slider?.perView > this.slider?.step ) {
+			totalNavItems = Math.ceil( ( totalSlides - this.slider?.perView ) / this.slider?.step ) + 1;
+		} else {
+			// Scenario 2: we can create nav items equal to number of slides group.
+			totalNavItems = this.slider?.getTotalSlidesGroupCount();
+		}
 
 		// Clear the navigation.
 		this.innerHTML = '';

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -253,12 +253,6 @@ export class TPSliderElement extends HTMLElement {
 	 * Navigate to the previous slide.
 	 */
 	previous(): void {
-		// Initialize total slides variable.
-		const totalSlides: number = this.getTotalSlides();
-
-		// Total Posible groups.
-		const totalPosibleGroups: number = this.totalSlidesGroups();
-
 		// Check if we are at the first slide.
 		if ( this.currentSlideIndex <= 1 ) {
 			// Check if we are in infinite mode.
@@ -270,6 +264,12 @@ export class TPSliderElement extends HTMLElement {
 			return;
 		}
 
+		// Initialize total slides variable.
+		const totalSlides: number = this.getTotalSlides();
+
+		// Total Posible groups.
+		const totalPosibleGroups: number = this.totalSlidesGroups();
+
 		// Check if we don't have round of number of slides.
 		if ( totalSlides / this.step !== Math.round( totalSlides / this.step ) ) {
 			// Checking in which group we are currently.
@@ -277,6 +277,7 @@ export class TPSliderElement extends HTMLElement {
 
 			// Setting Previous slide based on groups.
 			const previousSlideNumber: number = currentGroup === totalPosibleGroups ? this.currentSlideIndex - this.step + 1 : this.currentSlideIndex - this.step;
+
 			// Check if the previous slide step is not taking it beyond the first slide.
 			if ( previousSlideNumber > 1 ) {
 				this.setCurrentSlide( previousSlideNumber );
@@ -360,17 +361,17 @@ export class TPSliderElement extends HTMLElement {
 
 		// Check if behaviour is set to fade and slide on the current slide index is present in the slides array.
 		if ( 'fade' !== behaviour && slides[ this.currentSlideIndex - 1 ] ) {
-			const lastSlide = slides[slides.length - 1];
+			const lastSlide = slides[ slides.length - 1 ];
 			const lastSlideRightEdge = lastSlide.offsetLeft + lastSlide.getBoundingClientRect().width;
 			const containerWidth = slidesContainer.offsetWidth;
+			let newLeft = slides[ this.currentSlideIndex - 1 ].offsetLeft;
 
-			let newLeft = slides[this.currentSlideIndex - 1].offsetLeft;
 			// If the last slide's right edge exceeds the container width, adjust the left position
 			if ( this.getTotalSlides() - this.perView + 1 === this.currentSlideIndex ) {
-				if (lastSlideRightEdge > containerWidth) {
-					console.log( "In" )
+				// Check if last slide is hidden.
+				if ( lastSlideRightEdge > containerWidth ) {
 					const overflow = lastSlideRightEdge - containerWidth;
-					newLeft = Math.max(newLeft, overflow);
+					newLeft = Math.max( newLeft, overflow );
 				}
 			}
 

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -222,7 +222,6 @@ export class TPSliderElement extends HTMLElement {
 	 * Navigate to the next slide.
 	 */
 	next(): void {
-		console.log(this.getTotalSlidesGroupCount());
 		// Initialize total slides variable.
 		const totalSlides: number = this.getTotalSlides();
 
@@ -258,7 +257,6 @@ export class TPSliderElement extends HTMLElement {
 		// Check if we are at the first slide.
 		if ( this.currentSlideIndex <= 1 ) {
 			// Check if we are in infinite mode.
-			console.log( "total Slides: ", this.getTotalSlides(), "Per View: ", this.perView )
 			if ( 'yes' === this.getAttribute( 'infinite' ) ) {
 				this.setCurrentSlide( this.getTotalSlides() - this.perView + 1 );
 			}
@@ -312,8 +310,6 @@ export class TPSliderElement extends HTMLElement {
 	 * @param {number} index Slide index.
 	 */
 	setCurrentSlide( index: number ): void {
-
-		console.log("Index: ", index);
 		// Check if slide index is valid.
 		if ( index > this.getTotalSlides() || index <= 0 ) {
 			// Stop! It's not valid.
@@ -454,7 +450,6 @@ export class TPSliderElement extends HTMLElement {
 			sliderNavItems.forEach( ( navItem: TPSliderNavItemElement, index: number, allItems: NodeListOf<TPSliderNavItemElement> ): void => {
 				// Remove current attribute.
 				navItem.removeAttribute( 'current' );
-				console.log( "currentGroup", (index * this.step) + 1);
 
 				// Get Round of Index.
 				const groupIndex = Math.round( ( this.currentSlideIndex - 1 ) / this.step );

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -205,11 +205,12 @@ export class TPSliderElement extends HTMLElement {
 	}
 
 	/**
-	 * Get All Groups.
+	 * Calculates the total number of slides groups in the slider.
+	 * Each group contains a number of slides determined by the `step` property.
 	 *
-	 * @return {number} Total group.
+	 * @return {number} The total number of slide groups.
 	 */
-	totalSlidesGroups(): number {
+	getTotalSlidesGroupCount(): number {
 		// Get total slides.
 		const totalSlides: number = this.getTotalSlides();
 
@@ -221,6 +222,7 @@ export class TPSliderElement extends HTMLElement {
 	 * Navigate to the next slide.
 	 */
 	next(): void {
+		console.log(this.getTotalSlidesGroupCount());
 		// Initialize total slides variable.
 		const totalSlides: number = this.getTotalSlides();
 
@@ -256,6 +258,7 @@ export class TPSliderElement extends HTMLElement {
 		// Check if we are at the first slide.
 		if ( this.currentSlideIndex <= 1 ) {
 			// Check if we are in infinite mode.
+			console.log( "total Slides: ", this.getTotalSlides(), "Per View: ", this.perView )
 			if ( 'yes' === this.getAttribute( 'infinite' ) ) {
 				this.setCurrentSlide( this.getTotalSlides() - this.perView + 1 );
 			}
@@ -268,7 +271,7 @@ export class TPSliderElement extends HTMLElement {
 		const totalSlides: number = this.getTotalSlides();
 
 		// Total Posible groups.
-		const totalPosibleGroups: number = this.totalSlidesGroups();
+		const totalPosibleGroups: number = this.getTotalSlidesGroupCount();
 
 		// Check if we don't have round of number of slides.
 		if ( totalSlides / this.step !== Math.round( totalSlides / this.step ) ) {
@@ -313,6 +316,8 @@ export class TPSliderElement extends HTMLElement {
 	 * @param {number} index Slide index.
 	 */
 	setCurrentSlide( index: number ): void {
+
+		console.log("Index: ", index);
 		// Check if slide index is valid.
 		if ( index > this.getTotalSlides() || index <= 0 ) {
 			// Stop! It's not valid.
@@ -424,7 +429,7 @@ export class TPSliderElement extends HTMLElement {
 
 		// Total slides variable and Total posible group.
 		const totalSlides: number = this.getTotalSlides();
-		const totalPosibleGroups: number = this.totalSlidesGroups();
+		const totalPosibleGroups: number = this.getTotalSlidesGroupCount();
 
 		// Set active slide.
 		const slides: NodeListOf<TPSliderSlideElement> | null | undefined = this.getSlideElements();
@@ -453,6 +458,7 @@ export class TPSliderElement extends HTMLElement {
 			sliderNavItems.forEach( ( navItem: TPSliderNavItemElement, index: number, allItems: NodeListOf<TPSliderNavItemElement> ): void => {
 				// Remove current attribute.
 				navItem.removeAttribute( 'current' );
+				console.log( "currentGroup", (index * this.step) + 1);
 
 				// Get Round of Index.
 				const groupIndex = Math.round( ( this.currentSlideIndex - 1 ) / this.step );

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -360,8 +360,22 @@ export class TPSliderElement extends HTMLElement {
 
 		// Check if behaviour is set to fade and slide on the current slide index is present in the slides array.
 		if ( 'fade' !== behaviour && slides[ this.currentSlideIndex - 1 ] ) {
-			// Yes, it is. So slide to the current slide.
-			slidesContainer.style.left = `-${ slides[ this.currentSlideIndex - 1 ].offsetLeft }px`;
+			const lastSlide = slides[slides.length - 1];
+			const lastSlideRightEdge = lastSlide.offsetLeft + lastSlide.getBoundingClientRect().width;
+			const containerWidth = slidesContainer.offsetWidth;
+
+			let newLeft = slides[this.currentSlideIndex - 1].offsetLeft;
+			// If the last slide's right edge exceeds the container width, adjust the left position
+			if ( this.getTotalSlides() - this.perView + 1 === this.currentSlideIndex ) {
+				if (lastSlideRightEdge > containerWidth) {
+					console.log( "In" )
+					const overflow = lastSlideRightEdge - containerWidth;
+					newLeft = Math.max(newLeft, overflow);
+				}
+			}
+
+			// Slide to the current slide.
+			slidesContainer.style.left = `-${ newLeft }px`;
 		}
 	}
 

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -407,6 +407,10 @@ export class TPSliderElement extends HTMLElement {
 		const leftArrow: TPSliderArrowElement | null = this.getArrow( 'tp-slider-arrow[direction="previous"]' );
 		const rightArrow: TPSliderArrowElement | null = this.getArrow( 'tp-slider-arrow[direction="next"]' );
 
+		// Total slides variable and Total posible group.
+		const totalSlides: number = this.getTotalSlides();
+		const totalPosibleGroups: number = this.totalSlidesGroups();
+
 		// Set active slide.
 		const slides: NodeListOf<TPSliderSlideElement> | null | undefined = this.getSlideElements();
 
@@ -430,12 +434,22 @@ export class TPSliderElement extends HTMLElement {
 
 		// Set current slider nav item.
 		if ( sliderNavItems ) {
-			sliderNavItems.forEach( ( navItem: TPSliderNavItemElement, index: number ): void => {
-				// Update current attribute after considering step.
-				if ( Math.ceil( this.currentSlideIndex / this.step ) - 1 === index ) {
+			// Add current attribute.
+			sliderNavItems.forEach( ( navItem: TPSliderNavItemElement, index: number, allItems: NodeListOf<TPSliderNavItemElement> ): void => {
+				// Remove current attribute.
+				navItem.removeAttribute( 'current' );
+
+				// Get Round of Index.
+				const groupIndex = Math.round( ( this.currentSlideIndex - 1 ) / this.step );
+
+				// Check if index and groups are equal to update active dot.
+				if ( groupIndex === index ) {
 					navItem.setAttribute( 'current', 'yes' );
-				} else {
-					navItem.removeAttribute( 'current' );
+				} else if ( ( index === totalPosibleGroups - 1 && this.currentSlideIndex + this.step - 1 >= totalSlides ) ) {
+					navItem.setAttribute( 'current', 'yes' );
+
+					// Remove current index from last 2nd item.
+					allItems[ index - 1 ]?.removeAttribute( 'current' );
 				}
 			} );
 		}

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -273,30 +273,26 @@ export class TPSliderElement extends HTMLElement {
 		// Total Posible groups.
 		const totalPosibleGroups: number = this.getTotalSlidesGroupCount();
 
-		// Check if we don't have round of number of slides.
+		// Initialize previous slide number.
+		let previousSlideNumber: number = 0;
+
+		// Check if total slides are not multiple of step.
 		if ( totalSlides / this.step !== Math.round( totalSlides / this.step ) ) {
 			// Checking in which group we are currently.
 			const currentGroup: number = this.currentSlideIndex + this.step - 1 >= totalSlides ? totalPosibleGroups : Math.ceil( this.currentSlideIndex / this.step );
 
 			// Setting Previous slide based on groups.
-			const previousSlideNumber: number = currentGroup === totalPosibleGroups ? this.currentSlideIndex - this.step + 1 : this.currentSlideIndex - this.step;
-
-			// Check if the previous slide step is not taking it beyond the first slide.
-			if ( previousSlideNumber > 1 ) {
-				this.setCurrentSlide( previousSlideNumber );
-			} else {
-				this.setCurrentSlide( 1 );
-			}
+			previousSlideNumber = currentGroup === totalPosibleGroups ? this.currentSlideIndex - this.step + 1 : this.currentSlideIndex - this.step;
 		} else {
-			// Get previous slide index.
-			const previousSlideNumber: number = this.currentSlideIndex - this.step;
+			// Check if we are in the last group.
+			previousSlideNumber = this.currentSlideIndex - this.step;
+		}
 
-			// Check if the previous slide step is not taking it beyond the first slide.
-			if ( previousSlideNumber > 1 ) {
-				this.setCurrentSlide( previousSlideNumber );
-			} else {
-				this.setCurrentSlide( 1 );
-			}
+		// Check if the previous slide step is not taking it beyond the first slide.
+		if ( previousSlideNumber > 1 ) {
+			this.setCurrentSlide( previousSlideNumber );
+		} else {
+			this.setCurrentSlide( 1 );
 		}
 	}
 

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -237,7 +237,7 @@ export class TPSliderElement extends HTMLElement {
 		}
 
 		// Get next slide index by adding minimum of step or remaining number of slides.
-		const nextSlideIndex: number = this.currentSlideIndex + Math.min( this.step, totalSlides - this.currentSlideIndex - this.perView + 1 );
+		const nextSlideIndex: number = Math.min( this.currentSlideIndex + this.step, totalSlides - this.perView + 1 );
 
 		// Check if the next slide step is not taking it beyond the last slide.
 		if ( nextSlideIndex > ( totalSlides - this.perView + 1 ) ) {
@@ -253,6 +253,12 @@ export class TPSliderElement extends HTMLElement {
 	 * Navigate to the previous slide.
 	 */
 	previous(): void {
+		// Initialize total slides variable.
+		const totalSlides: number = this.getTotalSlides();
+
+		// Total Posible groups.
+		const totalPosibleGroups: number = this.totalSlidesGroups();
+
 		// Check if we are at the first slide.
 		if ( this.currentSlideIndex <= 1 ) {
 			// Check if we are in infinite mode.
@@ -264,14 +270,29 @@ export class TPSliderElement extends HTMLElement {
 			return;
 		}
 
-		// Get previous slide index.
-		const previousSlideNumber: number = this.currentSlideIndex - this.step;
+		// Check if we don't have round of number of slides.
+		if ( totalSlides / this.step !== Math.round( totalSlides / this.step ) ) {
+			// Checking in which group we are currently.
+			const currentGroup: number = this.currentSlideIndex + this.step - 1 >= totalSlides ? totalPosibleGroups : Math.ceil( this.currentSlideIndex / this.step );
 
-		// Check if the previous slide step is not taking it beyond the first slide.
-		if ( previousSlideNumber > 1 ) {
-			this.setCurrentSlide( previousSlideNumber );
+			// Setting Previous slide based on groups.
+			const previousSlideNumber: number = currentGroup === totalPosibleGroups ? this.currentSlideIndex - this.step + 1 : this.currentSlideIndex - this.step;
+			// Check if the previous slide step is not taking it beyond the first slide.
+			if ( previousSlideNumber > 1 ) {
+				this.setCurrentSlide( previousSlideNumber );
+			} else {
+				this.setCurrentSlide( 1 );
+			}
 		} else {
-			this.setCurrentSlide( 1 );
+			// Get previous slide index.
+			const previousSlideNumber: number = this.currentSlideIndex - this.step;
+
+			// Check if the previous slide step is not taking it beyond the first slide.
+			if ( previousSlideNumber > 1 ) {
+				this.setCurrentSlide( previousSlideNumber );
+			} else {
+				this.setCurrentSlide( 1 );
+			}
 		}
 	}
 

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -205,6 +205,19 @@ export class TPSliderElement extends HTMLElement {
 	}
 
 	/**
+	 * Get All Groups.
+	 *
+	 * @return {number} Total group.
+	 */
+	totalSlidesGroups(): number {
+		// Get total slides.
+		const totalSlides: number = this.getTotalSlides();
+
+		// Return total number of group based on steps.
+		return Math.ceil( totalSlides / this.step );
+	}
+
+	/**
 	 * Navigate to the next slide.
 	 */
 	next(): void {

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -358,22 +358,8 @@ export class TPSliderElement extends HTMLElement {
 
 		// Check if behaviour is set to fade and slide on the current slide index is present in the slides array.
 		if ( 'fade' !== behaviour && slides[ this.currentSlideIndex - 1 ] ) {
-			const lastSlide = slides[ slides.length - 1 ];
-			const lastSlideRightEdge = lastSlide.offsetLeft + lastSlide.getBoundingClientRect().width;
-			const containerWidth = slidesContainer.offsetWidth;
-			let newLeft = slides[ this.currentSlideIndex - 1 ].offsetLeft;
-
-			// If the last slide's right edge exceeds the container width, adjust the left position
-			if ( this.getTotalSlides() - this.perView + 1 === this.currentSlideIndex ) {
-				// Check if last slide is hidden.
-				if ( lastSlideRightEdge > containerWidth ) {
-					const overflow = lastSlideRightEdge - containerWidth;
-					newLeft = Math.max( newLeft, overflow );
-				}
-			}
-
-			// Slide to the current slide.
-			slidesContainer.style.left = `-${ newLeft }px`;
+			// Yes, it is. So slide to the current slide.
+			slidesContainer.style.left = `-${ slides[ this.currentSlideIndex - 1 ].offsetLeft }px`;
 		}
 	}
 


### PR DESCRIPTION
The following updates include.
1. Refactoring of nav Items dynamic count. include a condition where the step are less and per view are more. i.e. For 3 perView 1 or 2 step.
2. Make sure when we click on the nav item, it goes to the right slide.
3. If the preview is passed and the last slide is half in view, then slides as expected. i.e. if two and a half, one and half slides are in view.