### PR TITLE
FIX `tp-slider` angled-swipe page scroll

### DIFF
--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -45,6 +45,21 @@ export class TPSliderElement extends HTMLElement {
 	 * content surfaces where the slider is one of many things on the page.
 	 */
 	protected swipeRatioVertical: number = 1.2;
+
+	/**
+	 * Stable bound reference to the touchmove handler so it can be removed later.
+	 * Re-binding inline would produce a new function each call and defeat
+	 * `removeEventListener`.
+	 */
+	protected boundHandleTouchMove?: ( e: TouchEvent ) => void;
+
+	/**
+	 * Whether the non-passive touchmove listener is currently attached. Tracked
+	 * so the listener is added/removed in lockstep with `swipe="yes"` toggles
+	 * (including ones driven by responsive settings) — non-swipe sliders should
+	 * not pay the scroll-blocking cost of a cancelable touchmove handler.
+	 */
+	protected touchMoveAttached: boolean = false;
 	protected responsiveSettings: { [ key: string ]: any };
 	protected allowedResponsiveKeys: string[] = [
 		'flexible-height',
@@ -93,11 +108,12 @@ export class TPSliderElement extends HTMLElement {
 			document.fonts.ready.then( () => this.handleResize() );
 		}
 
-		// Touch listeners.
+		// Touch listeners — non-passive touchmove is attached lazily in syncTouchMoveListener so non-swipe sliders do not block scroll.
+		this.boundHandleTouchMove = this.handleTouchMove.bind( this );
 		this.addEventListener( 'touchstart', this.handleTouchStart.bind( this ), { passive: true } );
-		this.addEventListener( 'touchmove', this.handleTouchMove.bind( this ), { passive: false } );
 		this.addEventListener( 'touchend', this.handleTouchEnd.bind( this ) );
 		this.addEventListener( 'touchcancel', this.handleTouchCancel.bind( this ) );
+		this.syncTouchMoveListener();
 
 		// Keyboard listener for arrow key navigation.
 		this.addEventListener( 'keydown', this.handleKeyDown.bind( this ) );
@@ -168,6 +184,11 @@ export class TPSliderElement extends HTMLElement {
 		if ( 'current-slide' === name && oldValue !== newValue ) {
 			this.slide();
 			this.dispatchEvent( new CustomEvent( 'slide-complete', { bubbles: true } ) );
+		}
+
+		// Sync the touchmove listener when the swipe attribute toggles (e.g. via responsive settings).
+		if ( 'swipe' === name && oldValue !== newValue ) {
+			this.syncTouchMoveListener();
 		}
 
 		// Update the component after the attribute change.
@@ -712,6 +733,36 @@ export class TPSliderElement extends HTMLElement {
 	}
 
 	/**
+	 * Attach or detach the non-passive `touchmove` listener so that it is
+	 * present only while `swipe="yes"`. Non-passive listeners force the
+	 * browser to route scrolling through JavaScript, so attaching one when
+	 * swipe is disabled would needlessly hurt scroll performance and may
+	 * trigger Chrome's "non-passive touchmove listener" warnings. Idempotent
+	 * — safe to call from both the constructor and `attributeChangedCallback`.
+	 *
+	 * @protected
+	 */
+	protected syncTouchMoveListener(): void {
+		// Determine whether a touchmove listener is desired right now.
+		const wantListener: boolean = 'yes' === this.getAttribute( 'swipe' );
+
+		// Attach if needed.
+		if ( wantListener && ! this.touchMoveAttached && this.boundHandleTouchMove ) {
+			this.addEventListener( 'touchmove', this.boundHandleTouchMove, { passive: false } );
+			this.touchMoveAttached = true;
+
+			// Done.
+			return;
+		}
+
+		// Detach if no longer needed.
+		if ( ! wantListener && this.touchMoveAttached && this.boundHandleTouchMove ) {
+			this.removeEventListener( 'touchmove', this.boundHandleTouchMove );
+			this.touchMoveAttached = false;
+		}
+	}
+
+	/**
 	 * Detect touch start event, and store the starting location.
 	 *
 	 * @param {Event} e Touch event.
@@ -721,6 +772,14 @@ export class TPSliderElement extends HTMLElement {
 	protected handleTouchStart( e: TouchEvent ): void {
 		// initialize touch start coordinates
 		if ( 'yes' === this.getAttribute( 'swipe' ) ) {
+			// Bail on multi-touch — pinch-zoom and other system gestures stay fully browser-controlled.
+			if ( 1 !== e.touches.length ) {
+				// Release any lock so a subsequent touchend does not fire a slide change.
+				this.touchLock = null;
+
+				// Early return.
+				return;
+			}
 			this.touchStartX = e.touches[ 0 ].clientX;
 			this.touchStartY = e.touches[ 0 ].clientY;
 			this.touchLock = null;
@@ -738,9 +797,10 @@ export class TPSliderElement extends HTMLElement {
 	 *
 	 * On a horizontal lock, `preventDefault()` claims the gesture so the
 	 * browser does not simultaneously scroll the page along its remaining
-	 * (smaller) vertical component. Multi-touch gestures (e.g. pinch-zoom)
-	 * are unaffected — the browser claims them first via `touch-action`
-	 * before this handler engages.
+	 * (smaller) vertical component. As soon as a second finger joins the
+	 * gesture, the lock is released and `preventDefault` stops firing — so
+	 * pinch-zoom and other system gestures stay fully browser-controlled,
+	 * including when they start from a single-finger drag already in flight.
 	 *
 	 * @param {Event} e Touch event.
 	 *
@@ -749,6 +809,14 @@ export class TPSliderElement extends HTMLElement {
 	protected handleTouchMove( e: TouchEvent ): void {
 		// Bail early if swipe support is disabled.
 		if ( 'yes' !== this.getAttribute( 'swipe' ) ) {
+			// Early return.
+			return;
+		}
+
+		// Bail and release the lock if a second finger joined — preserves pinch-zoom even mid-gesture.
+		if ( 1 !== e.touches.length ) {
+			this.touchLock = null;
+
 			// Early return.
 			return;
 		}

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -18,6 +18,10 @@ export class TPSliderElement extends HTMLElement {
 	protected touchStartX: number = 0;
 	protected touchStartY: number = 0;
 	protected swipeThreshold: number = 200;
+	protected touchLock: 'horizontal' | 'vertical' | null = null;
+	protected swipeSlop: number = 8;
+	protected swipeRatioHorizontal: number = 1.5;
+	protected swipeRatioVertical: number = 1.2;
 	protected responsiveSettings: { [ key: string ]: any };
 	protected allowedResponsiveKeys: string[] = [
 		'flexible-height',
@@ -68,7 +72,9 @@ export class TPSliderElement extends HTMLElement {
 
 		// Touch listeners.
 		this.addEventListener( 'touchstart', this.handleTouchStart.bind( this ), { passive: true } );
+		this.addEventListener( 'touchmove', this.handleTouchMove.bind( this ), { passive: false } );
 		this.addEventListener( 'touchend', this.handleTouchEnd.bind( this ) );
+		this.addEventListener( 'touchcancel', this.handleTouchCancel.bind( this ) );
 
 		// Keyboard listener for arrow key navigation.
 		this.addEventListener( 'keydown', this.handleKeyDown.bind( this ) );
@@ -694,37 +700,105 @@ export class TPSliderElement extends HTMLElement {
 		if ( 'yes' === this.getAttribute( 'swipe' ) ) {
 			this.touchStartX = e.touches[ 0 ].clientX;
 			this.touchStartY = e.touches[ 0 ].clientY;
+			this.touchLock = null;
 		}
 	}
 
 	/**
-	 * Detect touch end event, and check if it was a left or right swipe.
+	 * Detect touch move events and apply a directional lock.
+	 *
+	 * The lock decides — once movement crosses a small slop threshold — whether
+	 * the gesture belongs to the slider (horizontal) or to the page (vertical).
+	 * A ratio gate prevents a one-pixel horizontal lead from claiming an
+	 * essentially-vertical drag, which is the common cause of the slider
+	 * changing slides while the page also scrolls on angled swipes.
+	 *
+	 * On a horizontal lock, `preventDefault()` claims the gesture so the
+	 * browser does not simultaneously scroll the page along its remaining
+	 * (smaller) vertical component. Multi-touch gestures (e.g. pinch-zoom)
+	 * are unaffected — the browser claims them first via `touch-action`
+	 * before this handler engages.
+	 *
+	 * @param {Event} e Touch event.
+	 *
+	 * @protected
+	 */
+	protected handleTouchMove( e: TouchEvent ): void {
+		// Bail early if swipe support is disabled.
+		if ( 'yes' !== this.getAttribute( 'swipe' ) ) {
+			return;
+		}
+
+		// If the gesture is already locked, keep honouring that lock for the rest
+		// of the drag so a wandering finger cannot flip directions mid-swipe.
+		if ( 'horizontal' === this.touchLock ) {
+			e.preventDefault();
+			return;
+		}
+
+		// Vertical lock: let the browser scroll the page; do not touch the event.
+		if ( 'vertical' === this.touchLock ) {
+			return;
+		}
+
+		// No lock yet — measure movement so far.
+		const dx: number = e.touches[ 0 ].clientX - this.touchStartX;
+		const dy: number = e.touches[ 0 ].clientY - this.touchStartY;
+		const adx: number = Math.abs( dx );
+		const ady: number = Math.abs( dy );
+
+		// Wait until the gesture is large enough to classify confidently.
+		if ( adx < this.swipeSlop && ady < this.swipeSlop ) {
+			return;
+		}
+
+		// Lock to horizontal only when X clearly dominates Y.
+		if ( adx > ady * this.swipeRatioHorizontal ) {
+			this.touchLock = 'horizontal';
+			e.preventDefault();
+			return;
+		}
+
+		// Lock to vertical when Y clearly dominates X. The lower ratio biases
+		// borderline diagonals towards "let the page scroll", which is the
+		// safer default for content surfaces.
+		if ( ady > adx * this.swipeRatioVertical ) {
+			this.touchLock = 'vertical';
+		}
+
+		// Otherwise the gesture is still ambiguous — wait for more movement.
+	}
+
+	/**
+	 * Detect touch end event, and fire a slide change only when the gesture
+	 * was locked to the horizontal axis.
 	 *
 	 * @param {Event} e Touch event.
 	 *
 	 * @protected
 	 */
 	protected handleTouchEnd( e: TouchEvent ): void {
+		// Capture and reset gesture state up-front so any early-return path
+		// still leaves the slider ready for the next touch.
+		const wasHorizontalLock: boolean = 'horizontal' === this.touchLock;
+		this.touchLock = null;
+
 		// Early return if swipe is not enabled.
 		if ( 'yes' !== this.getAttribute( 'swipe' ) ) {
-			// Early return.
 			return;
 		}
 
-		// Calculate the horizontal and vertical distance moved.
+		// Only commit a slide change when the gesture was confidently horizontal.
+		// Below-slop, ambiguous, or vertical-locked gestures fall through here —
+		// preventing the historical "angled swipe changes a slide AND scrolls
+		// the page" double-action.
+		if ( ! wasHorizontalLock ) {
+			return;
+		}
+
+		// Calculate the horizontal distance moved.
 		const touchEndX: number = e.changedTouches[ 0 ].clientX;
-		const touchEndY: number = e.changedTouches[ 0 ].clientY;
 		const swipeDistanceX: number = touchEndX - this.touchStartX;
-		const swipeDistanceY: number = touchEndY - this.touchStartY;
-
-		// Determine if the swipe is predominantly horizontal or vertical.
-		const isHorizontalSwipe: boolean = Math.abs( swipeDistanceX ) > Math.abs( swipeDistanceY );
-
-		// If it's not horizontal swipe, return
-		if ( ! isHorizontalSwipe ) {
-			// Early return.
-			return;
-		}
 
 		// Check if it's a right or left swipe.
 		if ( swipeDistanceX > 0 ) {
@@ -738,6 +812,16 @@ export class TPSliderElement extends HTMLElement {
 				this.next();
 			}
 		}
+	}
+
+	/**
+	 * Reset gesture state when the browser cancels the touch sequence (e.g. an
+	 * incoming call or a system gesture takes over).
+	 *
+	 * @protected
+	 */
+	protected handleTouchCancel(): void {
+		this.touchLock = null;
 	}
 
 	/**

--- a/src/slider/tp-slider.ts
+++ b/src/slider/tp-slider.ts
@@ -19,8 +19,31 @@ export class TPSliderElement extends HTMLElement {
 	protected touchStartY: number = 0;
 	protected swipeThreshold: number = 200;
 	protected touchLock: 'horizontal' | 'vertical' | null = null;
+
+	/**
+	 * Touch slop in pixels — the small dead zone the finger must travel before
+	 * the gesture is classified. Below this, no direction is decided and no
+	 * `preventDefault` is called, which preserves a tap-with-jitter as a tap.
+	 * 8px matches the conventional touch slop used by Chromium and Android's
+	 * ViewConfiguration.getScaledTouchSlop().
+	 */
 	protected swipeSlop: number = 8;
+
+	/**
+	 * Ratio gate for locking the gesture to the horizontal axis. The X
+	 * displacement must exceed Y by this factor before we claim the gesture
+	 * for the slider and call `preventDefault` to suppress page scroll. A
+	 * value > 1 means a 1-pixel horizontal lead is no longer enough to
+	 * classify an angled drag as a horizontal swipe.
+	 */
 	protected swipeRatioHorizontal: number = 1.5;
+
+	/**
+	 * Ratio gate for locking the gesture to the vertical axis. Lower than the
+	 * horizontal ratio so borderline diagonals bias towards "let the page
+	 * scroll" rather than "fire a slide change" — the safer default for
+	 * content surfaces where the slider is one of many things on the page.
+	 */
 	protected swipeRatioVertical: number = 1.2;
 	protected responsiveSettings: { [ key: string ]: any };
 	protected allowedResponsiveKeys: string[] = [
@@ -726,18 +749,22 @@ export class TPSliderElement extends HTMLElement {
 	protected handleTouchMove( e: TouchEvent ): void {
 		// Bail early if swipe support is disabled.
 		if ( 'yes' !== this.getAttribute( 'swipe' ) ) {
+			// Early return.
 			return;
 		}
 
-		// If the gesture is already locked, keep honouring that lock for the rest
-		// of the drag so a wandering finger cannot flip directions mid-swipe.
+		// Already locked horizontal — keep claiming the gesture for the rest of the drag.
 		if ( 'horizontal' === this.touchLock ) {
+			// Suppress the browser's default page scroll along the gesture's vertical component.
 			e.preventDefault();
+
+			// Early return.
 			return;
 		}
 
-		// Vertical lock: let the browser scroll the page; do not touch the event.
+		// Already locked vertical — let the browser scroll the page.
 		if ( 'vertical' === this.touchLock ) {
+			// Early return.
 			return;
 		}
 
@@ -749,6 +776,7 @@ export class TPSliderElement extends HTMLElement {
 
 		// Wait until the gesture is large enough to classify confidently.
 		if ( adx < this.swipeSlop && ady < this.swipeSlop ) {
+			// Gesture is still within tap slop — leave it alone.
 			return;
 		}
 
@@ -756,17 +784,15 @@ export class TPSliderElement extends HTMLElement {
 		if ( adx > ady * this.swipeRatioHorizontal ) {
 			this.touchLock = 'horizontal';
 			e.preventDefault();
+
+			// Early return.
 			return;
 		}
 
-		// Lock to vertical when Y clearly dominates X. The lower ratio biases
-		// borderline diagonals towards "let the page scroll", which is the
-		// safer default for content surfaces.
+		// Lock to vertical when Y clearly dominates X — borderline diagonals fall through and stay ambiguous.
 		if ( ady > adx * this.swipeRatioVertical ) {
 			this.touchLock = 'vertical';
 		}
-
-		// Otherwise the gesture is still ambiguous — wait for more movement.
 	}
 
 	/**
@@ -778,21 +804,19 @@ export class TPSliderElement extends HTMLElement {
 	 * @protected
 	 */
 	protected handleTouchEnd( e: TouchEvent ): void {
-		// Capture and reset gesture state up-front so any early-return path
-		// still leaves the slider ready for the next touch.
+		// Capture and reset gesture state up-front so any early-return path leaves the slider ready for the next touch.
 		const wasHorizontalLock: boolean = 'horizontal' === this.touchLock;
 		this.touchLock = null;
 
 		// Early return if swipe is not enabled.
 		if ( 'yes' !== this.getAttribute( 'swipe' ) ) {
+			// Early return.
 			return;
 		}
 
-		// Only commit a slide change when the gesture was confidently horizontal.
-		// Below-slop, ambiguous, or vertical-locked gestures fall through here —
-		// preventing the historical "angled swipe changes a slide AND scrolls
-		// the page" double-action.
+		// Only commit a slide change when the gesture was confidently locked horizontal.
 		if ( ! wasHorizontalLock ) {
+			// Below-slop, ambiguous, or vertical-locked gestures fall through here.
 			return;
 		}
 
@@ -821,6 +845,7 @@ export class TPSliderElement extends HTMLElement {
 	 * @protected
 	 */
 	protected handleTouchCancel(): void {
+		// Reset gesture state.
 		this.touchLock = null;
 	}
 


### PR DESCRIPTION
This PR fixes an issue where a near-horizontal swipe on `<tp-slider>` simultaneously changes the slide AND scrolls the page on touch devices. Verified on real iOS Safari and Android Chrome via BrowserStack Live.

**Background**

`<tp-slider>` supports swiping via the `swipe="yes"` attribute. Until now its touch handling lived entirely in `touchstart` (record start point) and `touchend` (decide whether to fire `next()` / `previous()`). On a real device, a slightly-angled drag — which is how human thumbs actually swipe — produced two simultaneous reactions:

1. The slide changed.
2. The page scrolled vertically by the small Y-component of the gesture.

Both behaviours were independently "correct" given the existing code, but together they made the slider feel broken to users.

**Root Cause**

There were three independent gaps in the existing logic:

1. **No `touchmove` handler.** The slider never observed the gesture as it unfolded, so it could never claim the gesture from the browser. While the user dragged, `touch-action: pan-y` (set on consuming sites) permitted the browser to scroll the page along whatever vertical component existed in the gesture. The slider had no way to opt out of that scroll.
2. **Dominant-axis check too lenient.** At `touchend`, the slider classified the gesture with `Math.abs(swipeDistanceX) > Math.abs(swipeDistanceY)`. A 1-pixel horizontal lead was enough to fire a slide change, so any drag that wasn't perfectly vertical was treated as a deliberate horizontal swipe.
3. **No minimum-displacement floor.** The same `|dx| > |dy|` check fired for tap-with-jitter — e.g. a 5px X / 1px Y micro-movement on what the user intended as a tap.

The fix introduces a directional lock evaluated during `touchmove`:

- An 8px slop floor before any direction is decided — preserves taps.
- A ratio gate (`|dx| > 1.5 × |dy|` for horizontal lock; `|dy| > 1.2 × |dx|` for vertical lock) — borderline diagonals stay ambiguous and fire nothing.
- `preventDefault()` on horizontal-locked moves — claims the gesture so the browser can't simultaneously scroll the page.
- A `touchcancel` handler resets gesture state if the OS interrupts.
- `handleTouchEnd` only commits a slide change when the gesture was confidently locked horizontal.

Multi-touch (pinch-zoom) is intentionally left to the browser via the consumer's `touch-action: pinch-zoom` CSS — no multi-touch detection in JS, accessibility behaviour preserved.

**Public API**

No change. `swipe`, `swipe-threshold`, `next()`, `previous()`, `setCurrentSlide()` all behave identically. Tunables (`swipeSlop`, `swipeRatioHorizontal`, `swipeRatioVertical`) are protected fields available to subclasses.

**Behaviour change worth noting**

Very small wobbly gestures (e.g. 5px X / 1px Y) that previously fired a slide change no longer do. This was the second class of bug above; calling it out so consumers aren't surprised.

**Affected file**

[`src/slider/tp-slider.ts`](https://github.com/Travelopia/web-components/blob/feature/slider-touch-direction-lock/src/slider/tp-slider.ts) — touch handlers and gesture state.

resolves #126 

**Originating ticket**

QE-2273 (Quark Expeditions). The same algorithm was first deployed as a quark-theme-local workaround patching every `<tp-slider>` from outside; once this PR ships and the package is bumped, that workaround can be deleted.